### PR TITLE
Add French and German automatic translations for each module (#15)

### DIFF
--- a/Modules/Avatus.lua
+++ b/Modules/Avatus.lua
@@ -39,15 +39,67 @@ mod:RegisterEnglishLocale({
 })
 mod:RegisterFrenchLocale({
 	-- Unit names.
+	["Avatus"] = "Avatus",
+	["Holo Hand"] = "Holo-main",
+--	["Holo Hand Spawned"] = "Holo Hand Spawned",	-- TODO: French translation missing !!!!
+	["Mobius Physics Constructor"] = "Constructeur de physique de Möbius",
+	["Unstoppable Object Simulation"] = "Simulacre invincible",
+	["Holo Cannon"] = "Holocanon",
+	["Shock Sphere"] = "Sphère de choc",
+	["Support Cannon"] = "Canon d'appui",
+	["Infinite Logic Loop"] = "Boucle de logique infinie",
 	-- Datachron messages.
+--	["Portals have opened!"] = "Portals have opened!",	-- TODO: French translation missing !!!!
+--	["Gun Grid Activated"] = "Gun Grid Activated",	-- TODO: French translation missing !!!!
 	-- Cast.
+	["Crushing Blow"] = "Coup écrasant",
+	["Data Flare"] = "Signal de données",
+	["Obliteration Beam"] = "Rayon de suppression",
 	-- Bar and messages.
+--	["PURGE BLUE BOSS"] = "PURGE BLUE BOSS",	-- TODO: French translation missing !!!!
+	["P2 SOON !"] = "P2 SOON !",
+--	["GO TO SIDES !"] = "GO TO SIDES !",	-- TODO: French translation missing !!!!
+--	["INTERRUPT CRUSHING BLOW!"] = "INTERRUPT CRUSHING BLOW!",	-- TODO: French translation missing !!!!
+--	["BLIND! TURN AWAY FROM BOSS"] = "BLIND! TURN AWAY FROM BOSS",	-- TODO: French translation missing !!!!
+	["Blind"] = "Aveugler",
+--	["Gun Grid NOW!"] = "Gun Grid NOW!",	-- TODO: French translation missing !!!!
+--	["~Gun Grid"] = "~Gun Grid",	-- TODO: French translation missing !!!!
+--	["Holo Hands spawn"] = "Holo Hands spawn",	-- TODO: French translation missing !!!!
+--	["Hand %u"] = "Hand %u",	-- TODO: French translation missing !!!!
+--	["MARKER North"] = "North",	-- TODO: French translation missing !!!!
+--	["MARKER South"] = "South",	-- TODO: French translation missing !!!!
 })
 mod:RegisterGermanLocale({
 	-- Unit names.
+	["Avatus"] = "Avatus",
+	["Holo Hand"] = "Holohand",
+--	["Holo Hand Spawned"] = "Holo Hand Spawned",	-- TODO: German translation missing !!!!
+	["Mobius Physics Constructor"] = "Mobius Physikkonstrukteur",
+	["Unstoppable Object Simulation"] = "Unaufhaltbare Objektsimulation",
+	["Holo Cannon"] = "Holokanone",
+	["Shock Sphere"] = "Schocksphäre",
+	["Support Cannon"] = "Hilfskanone",
+	["Infinite Logic Loop"] = "Unendliche Logikschleife",
 	-- Datachron messages.
+--	["Portals have opened!"] = "Portals have opened!",	-- TODO: German translation missing !!!!
+--	["Gun Grid Activated"] = "Gun Grid Activated",	-- TODO: German translation missing !!!!
 	-- Cast.
+	["Crushing Blow"] = "Vernichtender Schlag",
+	["Data Flare"] = "Daten-Leuchtsignal",
+	["Obliteration Beam"] = "Vernichtungsstrahl",
 	-- Bar and messages.
+--	["PURGE BLUE BOSS"] = "PURGE BLUE BOSS",	-- TODO: German translation missing !!!!
+	["P2 SOON !"] = "GLEICH PHASE 2 !",
+--	["GO TO SIDES !"] = "GO TO SIDES !",	-- TODO: German translation missing !!!!
+--	["INTERRUPT CRUSHING BLOW!"] = "INTERRUPT CRUSHING BLOW!",	-- TODO: German translation missing !!!!
+--	["BLIND! TURN AWAY FROM BOSS"] = "BLIND! TURN AWAY FROM BOSS",	-- TODO: German translation missing !!!!
+	["Blind"] = "Geblendet",
+--	["Gun Grid NOW!"] = "Gun Grid NOW!",	-- TODO: German translation missing !!!!
+--	["~Gun Grid"] = "~Gun Grid",	-- TODO: German translation missing !!!!
+--	["Holo Hands spawn"] = "Holo Hands spawn",	-- TODO: German translation missing !!!!
+--	["Hand %u"] = "Hand %u",	-- TODO: German translation missing !!!!
+--	["MARKER North"] = "North",	-- TODO: German translation missing !!!!
+--	["MARKER South"] = "South",	-- TODO: German translation missing !!!!
 })
 
 local phase2warn, phase2 = false, false

--- a/Modules/DSFireWing.lua
+++ b/Modules/DSFireWing.lua
@@ -37,19 +37,48 @@ mod:RegisterFrenchLocale({
 	["Warmonger Agratha"] = "Guerroyeuse Agratha",
 	["Warmonger Talarii"] = "Guerroyeuse Talarii",
 	["Warmonger Chuna"] = "Guerroyeuse Chuna",
+	["Grand Warmonger Tar'gresh"] = "Grand guerroyeur Tar'gresh",
 	["Conjured Fire Bomb"] = "Bombe incendiaire invoquée",
-	["Totem's Fire"] = "Totem de feu invoqué",
 	-- Datachron messages.
 	-- NPCSay messages.
 	-- Cast.
+	["Incineration"] = "Incinération",
+	["Conjure Fire Elementals"] = "Invocation d'Élémentaires de feu",
+	["Meteor Storm"] = "Pluie de météores",
 	-- Bar and messages.
+--	["INTERRUPT !"] = "INTERRUPT !",	-- TODO: French translation missing !!!!
+--	["ELEMENTALS SOON"] = "ELEMENTALS SOON",	-- TODO: French translation missing !!!!
+--	["ELEMENTALS"] = "ELEMENTALS",	-- TODO: French translation missing !!!!
+--	["FIRST ABILITY"] = "FIRST ABILITY",	-- TODO: French translation missing !!!!
+--	["SECOND ABILITY"] = "SECOND ABILITY",	-- TODO: French translation missing !!!!
+--	["STORM !!"] = "STORM !!",	-- TODO: French translation missing !!!!
+--	["METEOR STORM"] = "METEOR STORM",	-- TODO: French translation missing !!!!
+	["KNOCKBACK"] = "KNOCKBACK",
+--	["BOMB"] = "BOMB",	-- TODO: French translation missing !!!!
 })
 mod:RegisterGermanLocale({
 	-- Unit names.
+	["Warmonger Agratha"] = "Kriegstreiberin Agratha",
+	["Warmonger Talarii"] = "Kriegstreiberin Talarii",
+	["Warmonger Chuna"] = "Kriegstreiberin Chuna",
+	["Grand Warmonger Tar'gresh"] = "Großer Kriegstreiber Tar’gresh",
+	["Conjured Fire Bomb"] = "Beschworene Feuerbombe",
 	-- Datachron messages.
 	-- NPCSay messages.
 	-- Cast.
+	["Incineration"] = "Lodernde Flammen",
+	["Conjure Fire Elementals"] = "Feuerelementare beschwören",
+	["Meteor Storm"] = "Meteorsturm",
 	-- Bar and messages.
+--	["INTERRUPT !"] = "INTERRUPT !",	-- TODO: German translation missing !!!!
+--	["ELEMENTALS SOON"] = "ELEMENTALS SOON",	-- TODO: German translation missing !!!!
+--	["ELEMENTALS"] = "ELEMENTALS",	-- TODO: German translation missing !!!!
+--	["FIRST ABILITY"] = "FIRST ABILITY",	-- TODO: German translation missing !!!!
+--	["SECOND ABILITY"] = "SECOND ABILITY",	-- TODO: German translation missing !!!!
+--	["STORM !!"] = "STORM !!",	-- TODO: German translation missing !!!!
+--	["METEOR STORM"] = "METEOR STORM",	-- TODO: German translation missing !!!!
+	["KNOCKBACK"] = "RÜCKSTOß",
+--	["BOMB"] = "BOMB",	-- TODO: German translation missing !!!!
 })
 
 --------------------------------------------------------------------------------

--- a/Modules/DSFrostWing.lua
+++ b/Modules/DSFrostWing.lua
@@ -45,15 +45,39 @@ mod:RegisterEnglishLocale({
 })
 mod:RegisterFrenchLocale({
 	-- Unit names.
-	-- Datachron messages.
+	["Frost-Boulder Avalanche"] = "Avalanche cryoroc",
+	["Frostbringer Warlock"] = "Sorcier cryogène",
 	-- Cast.
+	["Icicle Storm"] = "Tempête de stalactites",
+	["Shatter"] = "Fracasser",
+	["Cyclone"] = "Cyclone",
 	-- Bar and messages.
+--	["CYCLONE SOON"] = "CYCLONE SOON",	-- TODO: French translation missing !!!!
+--	["ICICLE"] = "ICICLE",	-- TODO: French translation missing !!!!
+--	["PHASE 2 SOON"] = "PHASE 2 SOON",	-- TODO: French translation missing !!!!
+--	["1ST ABILITY"] = "1ST ABILITY",	-- TODO: French translation missing !!!!
+--	["2ND ABILITY"] = "2ND ABILITY",	-- TODO: French translation missing !!!!
+--	["3RD ABILITY"] = "3RD ABILITY",	-- TODO: French translation missing !!!!
+--	["FROST WAVE"] = "FROST WAVE",	-- TODO: French translation missing !!!!
+--	["RUNNNN"] = "RUNNNN",	-- TODO: French translation missing !!!!
 })
 mod:RegisterGermanLocale({
 	-- Unit names.
-	-- Datachron messages.
+	["Frost-Boulder Avalanche"] = "Frostfelsen-Lawine",
+	["Frostbringer Warlock"] = "Frostbringer-Hexenmeister",
 	-- Cast.
+	["Icicle Storm"] = "Eiszapfensturm",
+	["Shatter"] = "Zerschmettern",
+	["Cyclone"] = "Wirbelsturm",
 	-- Bar and messages.
+--	["CYCLONE SOON"] = "CYCLONE SOON",	-- TODO: German translation missing !!!!
+--	["ICICLE"] = "ICICLE",	-- TODO: German translation missing !!!!
+--	["PHASE 2 SOON"] = "PHASE 2 SOON",	-- TODO: German translation missing !!!!
+--	["1ST ABILITY"] = "1ST ABILITY",	-- TODO: German translation missing !!!!
+--	["2ND ABILITY"] = "2ND ABILITY",	-- TODO: German translation missing !!!!
+--	["3RD ABILITY"] = "3RD ABILITY",	-- TODO: German translation missing !!!!
+--	["FROST WAVE"] = "FROST WAVE",	-- TODO: German translation missing !!!!
+--	["RUNNNN"] = "RUNNNN",	-- TODO: German translation missing !!!!
 })
 
 

--- a/Modules/DSLogicWing.lua
+++ b/Modules/DSLogicWing.lua
@@ -29,15 +29,41 @@ mod:RegisterEnglishLocale({
 })
 mod:RegisterFrenchLocale({
 	-- Unit names.
+	["Conjured Fire Bomb"] = "Bombe incendiaire invoquée",
+	["Abstract Augmentation Algorithm"] = "Algorithme d'augmentation abstrait",
+	["Augmented Herald of Avatus"] = "Messager d'Avatus augmenté",
+	["Quantum Processing Unit"] = "Processeur quantique",
+	["Hyper-Accelerated Skeledroid"] = "Crânedroïde hyper-accéléré",
 	-- Datachron messages.
+--	["The Abstract Augmentation Algorithm has amplified a Quantum Processing Unit"] = "The Abstract Augmentation Algorithm has amplified a Quantum Processing Unit",	-- TODO: French translation missing !!!!
 	-- Cast.
+	["Data Deconstruction"] = "Déconstruction de données",
 	-- Bar and messages.
+--	["[%u] INTERRUPT"] = "[%u] INTERRUPT",	-- TODO: French translation missing !!!!
+--	["HEAL SOON"] = "HEAL SOON",	-- TODO: French translation missing !!!!
+--	["CUBE SMASH"] = "CUBE SMASH",	-- TODO: French translation missing !!!!
+--	["EMPOWER"] = "EMPOWER%s",	-- TODO: French translation missing !!!!
+--	["BOMB"] = "BOMB",	-- TODO: French translation missing !!!!
+	["BERSERK"] = "BERSERK",
 })
 mod:RegisterGermanLocale({
 	-- Unit names.
+	["Conjured Fire Bomb"] = "Beschworene Feuerbombe",
+	["Abstract Augmentation Algorithm"] = "Abstrakter Augmentations-Algorithmus",
+	["Augmented Herald of Avatus"] = "Avatus’ augmentierter Herold",
+	["Quantum Processing Unit"] = "Quantum-Aufbereitungseinheit",
+	["Hyper-Accelerated Skeledroid"] = "Hyper-beschleunigter Skeledroid",
 	-- Datachron messages.
+--	["The Abstract Augmentation Algorithm has amplified a Quantum Processing Unit"] = "The Abstract Augmentation Algorithm has amplified a Quantum Processing Unit",	-- TODO: German translation missing !!!!
 	-- Cast.
+	["Data Deconstruction"] = "Datendekonstruktion",
 	-- Bar and messages.
+--	["[%u] INTERRUPT"] = "[%u] INTERRUPT",	-- TODO: German translation missing !!!!
+--	["HEAL SOON"] = "HEAL SOON",	-- TODO: German translation missing !!!!
+--	["CUBE SMASH"] = "CUBE SMASH",	-- TODO: German translation missing !!!!
+--	["EMPOWER"] = "EMPOWER%s",	-- TODO: German translation missing !!!!
+--	["BOMB"] = "BOMB",	-- TODO: German translation missing !!!!
+	["BERSERK"] = "BERSERK",
 })
 
 --------------------------------------------------------------------------------

--- a/Modules/EpAirLife.lua
+++ b/Modules/EpAirLife.lua
@@ -36,16 +36,51 @@ mod:RegisterEnglishLocale({
 })
 mod:RegisterFrenchLocale({
 	-- Unit names.
+	["Visceralus"] = "Visceralus",
 	["Aileron"] = "Ventemort",
+	["Wild Brambles"] = "Ronces sauvages",
+--	["[DS] e395 - Air - Tornado"] = "[DS] e395 - Air - Tornado",	-- TODO: French translation missing !!!!
+	["Life Force"] = "Force vitale",
+	["Lifekeeper"] = "Garde-vie",
 	-- Datachron messages.
 	-- Cast.
+	["Blinding Light"] = "Lumière aveuglante",
 	-- Bar and messages.
+--	["TWIRL ON YOU!"] = "TWIRL ON YOU!",	-- TODO: French translation missing !!!!
+	["Thorns"] = "Épines",
+	["Twirl"] = "Tournoiement",
+--	["Midphase ending"] = "Midphase ending",	-- TODO: French translation missing !!!!
+--	["Middle Phase"] = "Middle Phase",	-- TODO: French translation missing !!!!
+--	["Next Healing Tree"] = "Next Healing Tree",	-- TODO: French translation missing !!!!
+--	["No-Healing Debuff!"] = "No-Healing Debuff!",	-- TODO: French translation missing !!!!
+--	["NO HEAL DEBUFF"] = "NO HEAL\nDEBUFF",	-- TODO: French translation missing !!!!
+	["Lightning"] = "Foudre",
+--	["Lightning on YOU"] = "Lightning on YOU",	-- TODO: French translation missing !!!!
+--	["Recently Saved!"] = "Recently Saved!",	-- TODO: French translation missing !!!!
 })
 mod:RegisterGermanLocale({
 	-- Unit names.
+	["Visceralus"] = "Viszeralus",
+	["Aileron"] = "Aileron",
+	["Wild Brambles"] = "Wilde Brombeeren",
+--	["[DS] e395 - Air - Tornado"] = "[DS] e395 - Air - Tornado",	-- TODO: German translation missing !!!!
+	["Life Force"] = "Lebenskraft",
+	["Lifekeeper"] = "Lebensbewahrer",
 	-- Datachron messages.
 	-- Cast.
+	["Blinding Light"] = "Blendendes Licht",
 	-- Bar and messages.
+--	["TWIRL ON YOU!"] = "TWIRL ON YOU!",	-- TODO: German translation missing !!!!
+	["Thorns"] = "Dornen",
+	["Twirl"] = "Wirbel",
+--	["Midphase ending"] = "Midphase ending",	-- TODO: German translation missing !!!!
+--	["Middle Phase"] = "Middle Phase",	-- TODO: German translation missing !!!!
+--	["Next Healing Tree"] = "Next Healing Tree",	-- TODO: German translation missing !!!!
+--	["No-Healing Debuff!"] = "No-Healing Debuff!",	-- TODO: German translation missing !!!!
+--	["NO HEAL DEBUFF"] = "NO HEAL\nDEBUFF",	-- TODO: German translation missing !!!!
+	["Lightning"] = "Blitz",
+--	["Lightning on YOU"] = "Lightning on YOU",	-- TODO: German translation missing !!!!
+--	["Recently Saved!"] = "Recently Saved!",	-- TODO: German translation missing !!!!
 })
 
 -- Tracking Blinding Light and Aileron knockback seems too random to display on timers.

--- a/Modules/EpEarthAir.lua
+++ b/Modules/EpEarthAir.lua
@@ -28,15 +28,35 @@ mod:RegisterEnglishLocale({
 })
 mod:RegisterFrenchLocale({
 	-- Unit names.
+	["Megalith"] = "Mégalithe",
+	["Aileron"] = "Ventemort",
+	["Air Column"] = "Colonne d'air",
 	-- Datachron messages.
+--	["The ground shudders beneath Megalith"] = "The ground shudders beneath Megalith",	-- TODO: French translation missing !!!!
+--	["fractured crust leaves it exposed"] = "fractured crust leaves it exposed",	-- TODO: French translation missing !!!!
 	-- Cast.
+	["Supercell"] = "Super-cellule",
+	["Raw Power"] = "Énergie brute",
 	-- Bar and messages.
+--	["MOO !"] = "MOO !",	-- TODO: French translation missing !!!!
+--	["EARTH"] = "EARTH",	-- TODO: French translation missing !!!!
+--	["~Tornado Spawn"] = "~Tornado Spawn",	-- TODO: French translation missing !!!!
 })
 mod:RegisterGermanLocale({
 	-- Unit names.
+	["Megalith"] = "Megalith",
+	["Aileron"] = "Aileron",
+	["Air Column"] = "Luftsäule",
 	-- Datachron messages.
+--	["The ground shudders beneath Megalith"] = "The ground shudders beneath Megalith",	-- TODO: German translation missing !!!!
+--	["fractured crust leaves it exposed"] = "fractured crust leaves it exposed",	-- TODO: German translation missing !!!!
 	-- Cast.
+	["Supercell"] = "Superzelle",
+	["Raw Power"] = "Rohe Kraft",
 	-- Bar and messages.
+--	["MOO !"] = "MOO !",	-- TODO: German translation missing !!!!
+--	["EARTH"] = "EARTH",	-- TODO: German translation missing !!!!
+--	["~Tornado Spawn"] = "~Tornado Spawn",	-- TODO: German translation missing !!!!
 })
 
 --------------------------------------------------------------------------------

--- a/Modules/EpEarthLogic.lua
+++ b/Modules/EpEarthLogic.lua
@@ -31,15 +31,41 @@ mod:RegisterEnglishLocale({
 })
 mod:RegisterFrenchLocale({
 	-- Unit names.
+	["Megalith"] = "Mégalithe",
+	["Mnemesis"] = "Mnémésis",
+--	["Obsidian Outcropping"] = "Obsidian Outcropping",	-- TODO: French translation missing !!!!
+	["Crystalline Matrix"] = "Matrice cristalline",
 	-- Datachron messages.
+--	["The ground shudders beneath Megalith"] = "The ground shudders beneath Megalith",	-- TODO: French translation missing !!!!
+--	["Logic creates powerful data caches"] = "Logic creates powerful data caches",	-- TODO: French translation missing !!!!
 	-- Cast.
+	["Defragment"] = "Défragmentation",
 	-- Bar and messages.
+--	["SNAKE ON %s"] = "SNAKE ON %s",	-- TODO: French translation missing !!!!
+--	["DEFRAG"] = "DEFRAG",	-- TODO: French translation missing !!!!
+--	["SPREAD"] = "SPREAD",	-- TODO: French translation missing !!!!
+--	["BOOM"] = "BOOM",	-- TODO: French translation missing !!!!
+--	["JUMP !"] = "JUMP !",	-- TODO: French translation missing !!!!
+--	["STARS"] = "STARS%s"	-- TODO: French translation missing !!!!
 })
 mod:RegisterGermanLocale({
 	-- Unit names.
+	["Megalith"] = "Megalith",
+	["Mnemesis"] = "Mnemesis",
+--	["Obsidian Outcropping"] = "Obsidian Outcropping",	-- TODO: German translation missing !!!!
+	["Crystalline Matrix"] = "Kristallmatrix",
 	-- Datachron messages.
+--	["The ground shudders beneath Megalith"] = "The ground shudders beneath Megalith",	-- TODO: German translation missing !!!!
+--	["Logic creates powerful data caches"] = "Logic creates powerful data caches",	-- TODO: German translation missing !!!!
 	-- Cast.
+	["Defragment"] = "Defragmentieren",
 	-- Bar and messages.
+--	["SNAKE ON %s"] = "SNAKE ON %s",	-- TODO: German translation missing !!!!
+--	["DEFRAG"] = "DEFRAG",	-- TODO: German translation missing !!!!
+--	["SPREAD"] = "SPREAD",	-- TODO: German translation missing !!!!
+--	["BOOM"] = "BOOM",	-- TODO: German translation missing !!!!
+--	["JUMP !"] = "JUMP !",	-- TODO: German translation missing !!!!
+--	["STARS"] = "STARS%s"	-- TODO: German translation missing !!!!
 })
 
 --------------------------------------------------------------------------------

--- a/Modules/EpFrostAir.lua
+++ b/Modules/EpFrostAir.lua
@@ -35,15 +35,49 @@ mod:RegisterEnglishLocale({
 })
 mod:RegisterFrenchLocale({
 	-- Unit names.
+	["Hydroflux"] = "Hydroflux",
+	["Aileron"] = "Ventemort",
+--	["Landing Volume"] = "Landing Volume",	-- TODO: French translation missing !!!!
+	["Wind Wall"] = "Mur de vent",
 	-- Datachron messages.
+--	["Hydroflux evaporates"] = "Hydroflux evaporates",	-- TODO: French translation missing !!!!
+--	["Aileron dissipates with a flurry"] = "Aileron dissipates with a flurry",	-- TODO: French translation missing !!!!
+--	["The wind starts to blow faster and faster"] = "The wind starts to blow faster and faster",	-- TODO: French translation missing !!!!
 	-- Cast.
+	["Tsunami"] = "Tsunami",
+	["Glacial Icestorm"] = "Glacial Icestorm",
 	-- Bar and messages.
+--	["EYE OF THE STORM"] = "EYE OF THE STORM",	-- TODO: French translation missing !!!!
+--	["MOO !"] = "MOO !",	-- TODO: French translation missing !!!!
+	["MOO PHASE"] = "MOO PHASE",
+--	["ICESTORM"] = "ICESTORM",	-- TODO: French translation missing !!!!
+--	["~Middle Phase"] = "~Middle Phase",	-- TODO: French translation missing !!!!
+--	["~Frost Tombs"] = "~Frost Tombs",	-- TODO: French translation missing !!!!
+--	["TWIRL ON YOU!"] = "TWIRL ON YOU!",	-- TODO: French translation missing !!!!
+--	["TWIRL"] = "TWIRL",	-- TODO: French translation missing !!!!
 })
 mod:RegisterGermanLocale({
 	-- Unit names.
+	["Hydroflux"] = "Hydroflux",
+	["Aileron"] = "Aileron",
+--	["Landing Volume"] = "Landing Volume",	-- TODO: German translation missing !!!!
+	["Wind Wall"] = "Windwand",
 	-- Datachron messages.
+--	["Hydroflux evaporates"] = "Hydroflux evaporates",	-- TODO: German translation missing !!!!
+--	["Aileron dissipates with a flurry"] = "Aileron dissipates with a flurry",	-- TODO: German translation missing !!!!
+--	["The wind starts to blow faster and faster"] = "The wind starts to blow faster and faster",	-- TODO: German translation missing !!!!
 	-- Cast.
+	["Tsunami"] = "Tsunami",
+	["Glacial Icestorm"] = "Frostiger Eissturm",
 	-- Bar and messages.
+--	["EYE OF THE STORM"] = "EYE OF THE STORM",	-- TODO: German translation missing !!!!
+--	["MOO !"] = "MOO !",	-- TODO: German translation missing !!!!
+--	["MOO PHASE"] = "MOO PHASE",	-- TODO: German translation missing !!!!
+--	["ICESTORM"] = "ICESTORM",	-- TODO: German translation missing !!!!
+--	["~Middle Phase"] = "~Middle Phase",	-- TODO: German translation missing !!!!
+--	["~Frost Tombs"] = "~Frost Tombs",	-- TODO: German translation missing !!!!
+--	["TWIRL ON YOU!"] = "TWIRL ON YOU!",	-- TODO: German translation missing !!!!
+--	["TWIRL"] = "TWIRL",	-- TODO: German translation missing !!!!
 })
 
 --------------------------------------------------------------------------------

--- a/Modules/EpFrostFire.lua
+++ b/Modules/EpFrostFire.lua
@@ -33,15 +33,45 @@ mod:RegisterEnglishLocale({
 })
 mod:RegisterFrenchLocale({
 	-- Unit names.
+	["Hydroflux"] = "Hydroflux",
+	["Pyrobane"] = "Pyromagnus",
+	["Ice Tomb"] = "Tombeau de glace",
 	-- Datachron messages.
+	-- NPCSay messages.
+--	["Burning mortals... such sweet agony"] = "Burning mortals... such sweet agony",	-- TODO: French translation missing !!!!
+--	["Run! Soon my fires will destroy you"] = "Run! Soon my fires will destroy you",	-- TODO: French translation missing !!!!
+--	["Ah! The smell of seared flesh"] = "Ah! The smell of seared flesh",	-- TODO: French translation missing !!!!
+--	["Enshrouded in deadly flame"] = "Enshrouded in deadly flame",	-- TODO: French translation missing !!!!
+--	["Pyrobane ignites you"] = "Pyrobane ignites you",	-- TODO: French translation missing !!!!
 	-- Cast.
+	["Flame Wave"] = "Vague de feu",
 	-- Bar and messages.
+--	["Frost Bomb"] = "Frost\nBomb",	-- TODO: French translation missing !!!!
+--	["BOMBS"] = "BOMBS",	-- TODO: French translation missing !!!!
+--	["BOMBS UP !"] = "BOMBS UP !",	-- TODO: French translation missing !!!!
+	["Bomb Explosion"] = "Bomb Explosion",
+--	["ICE TOMB"] = "ICE TOMB",	-- TODO: French translation missing !!!!
 })
 mod:RegisterGermanLocale({
 	-- Unit names.
+	["Hydroflux"] = "Hydroflux",
+	["Pyrobane"] = "Pyroman",
+	["Ice Tomb"] = "Eisgrab",
 	-- Datachron messages.
+	-- NPCSay messages.
+--	["Burning mortals... such sweet agony"] = "Burning mortals... such sweet agony",	-- TODO: German translation missing !!!!
+--	["Run! Soon my fires will destroy you"] = "Run! Soon my fires will destroy you",	-- TODO: German translation missing !!!!
+--	["Ah! The smell of seared flesh"] = "Ah! The smell of seared flesh",	-- TODO: German translation missing !!!!
+--	["Enshrouded in deadly flame"] = "Enshrouded in deadly flame",	-- TODO: German translation missing !!!!
+--	["Pyrobane ignites you"] = "Pyrobane ignites you",	-- TODO: German translation missing !!!!
 	-- Cast.
+	["Flame Wave"] = "Flammenwelle",
 	-- Bar and messages.
+--	["Frost Bomb"] = "Frost\nBomb",	-- TODO: German translation missing !!!!
+--	["BOMBS"] = "BOMBS",	-- TODO: German translation missing !!!!
+--	["BOMBS UP !"] = "BOMBS UP !",	-- TODO: German translation missing !!!!
+	["Bomb Explosion"] = "Bomb Explosion",
+--	["ICE TOMB"] = "ICE TOMB",	-- TODO: German translation missing !!!!
 })
 
 --------------------------------------------------------------------------------

--- a/Modules/EpFrostLogic.lua
+++ b/Modules/EpFrostLogic.lua
@@ -31,15 +31,43 @@ mod:RegisterEnglishLocale({
 })
 mod:RegisterFrenchLocale({
 	-- Unit names.
+	["Mnemesis"] = "Mnémésis",
+	["Hydroflux"] = "Hydroflux",
+	["Alphanumeric Hash"] = "Hachis alphanumérique",
+--	["Hydro Disrupter - DNT"] = "Hydro Disrupter - DNT",	-- TODO: French translation missing !!!!
 	-- Datachron messages.
 	-- Cast.
+	["Circuit Breaker"] = "Coupe-circuit",
+	["Imprison"] = "Emprisonner",
+	["Defragment"] = "Défragmentation",
+	["Watery Grave"] = "Tombe aqueuse",
 	-- Bar and messages.
+--	["Middle Phase"] = "Middle Phase",	-- TODO: French translation missing !!!!
+--	["SPREAD"] = "SPREAD",	-- TODO: French translation missing !!!!
+--	["~Defrag"] = "~Defrag",	-- TODO: French translation missing !!!!
+	["Defrag"] = "Défragmentation",
+--	["Stay away from boss with buff!"] = "Stay away from boss with buff!",	-- TODO: French translation missing !!!!
+--	["ORB"] = "ORB",	-- TODO: French translation missing !!!!
 })
 mod:RegisterGermanLocale({
 	-- Unit names.
+	["Mnemesis"] = "Mnemesis",
+	["Hydroflux"] = "Hydroflux",
+	["Alphanumeric Hash"] = "Alphanumerische Raute",
+--	["Hydro Disrupter - DNT"] = "Hydro Disrupter - DNT",	-- TODO: German translation missing !!!!
 	-- Datachron messages.
 	-- Cast.
+	["Circuit Breaker"] = "Schutzschalter",
+	["Imprison"] = "Einsperren",
+	["Defragment"] = "Defragmentieren",
+	["Watery Grave"] = "Seemannsgrab",
 	-- Bar and messages.
+--	["Middle Phase"] = "Middle Phase",	-- TODO: German translation missing !!!!
+--	["SPREAD"] = "SPREAD",	-- TODO: German translation missing !!!!
+--	["~Defrag"] = "~Defrag",	-- TODO: German translation missing !!!!
+	["Defrag"] = "Defrag",
+--	["Stay away from boss with buff!"] = "Stay away from boss with buff!",	-- TODO: German translation missing !!!!
+--	["ORB"] = "ORB",	-- TODO: German translation missing !!!!
 })
 
 --------------------------------------------------------------------------------

--- a/Modules/EpLifeFire.lua
+++ b/Modules/EpLifeFire.lua
@@ -26,15 +26,31 @@ mod:RegisterEnglishLocale({
 })
 mod:RegisterFrenchLocale({
 	-- Unit names.
+	["Visceralus"] = "Visceralus",
+	["Pyrobane"] = "Pyromagnus",
+	["Life Force"] = "Force vitale",
+	["Essence of Life"] = "Essence de vie",
+	["Flame Wave"] = "Vague de feu",
 	-- Datachron messages.
 	-- Cast.
+	["Blinding Light"] = "Lumière aveuglante",
 	-- Bar and messages.
+--	["You are rooted"] = "You are rooted",	-- TODO: French translation missing !!!!
+--	["MIDPHASE"] = "MIDPHASE",	-- TODO: French translation missing !!!!
 })
 mod:RegisterGermanLocale({
 	-- Unit names.
+	["Visceralus"] = "Viszeralus",
+	["Pyrobane"] = "Pyroman",
+	["Life Force"] = "Lebenskraft",
+	["Essence of Life"] = "Lebensessenz",
+	["Flame Wave"] = "Flammenwelle",
 	-- Datachron messages.
 	-- Cast.
+	["Blinding Light"] = "Blendendes Licht",
 	-- Bar and messages.
+--	["You are rooted"] = "You are rooted",	-- TODO: German translation missing !!!!
+--	["MIDPHASE"] = "MIDPHASE",	-- TODO: German translation missing !!!!
 })
 
 local DEBUFFID_PRIMAL_ENTANGLEMENT = 73179 -- A root ability.

--- a/Modules/EpLifeLogic.lua
+++ b/Modules/EpLifeLogic.lua
@@ -39,15 +39,59 @@ mod:RegisterEnglishLocale({
 })
 mod:RegisterFrenchLocale({
 	-- Unit names.
+	["Essence of Life"] = "Essence de vie",
+	["Essence of Logic"] = "Essence de logique",
+	["Alphanumeric Hash"] = "Hachis alphanumérique",
+	["Life Force"] = "Force vitale",
+	["Mnemesis"] = "Mnémésis",
+	["Visceralus"] = "Visceralus",
 	-- Datachron messages.
 	-- Cast.
+	["Blinding Light"] = "Lumière aveuglante",
+	["Defragment"] = "Défragmentation",
 	-- Bar and messages.
+--	["Defrag Explosion"] = "Defrag Explosion",	-- TODO: French translation missing !!!!
+--	["~DEFRAG CD"] = "~DEFRAG CD",	-- TODO: French translation missing !!!!
+--	["DEFRAG"] = "DEFRAG",	-- TODO: French translation missing !!!!
+--	["ENRAGE"] = "ENRAGE",	-- TODO: French translation missing !!!!
+--	["No-Healing Debuff!"] = "No-Healing Debuff!",	-- TODO: French translation missing !!!!
+--	["NO HEAL DEBUFF"] = "NO HEAL\nDEBUFF",	-- TODO: French translation missing !!!!
+--	["SNAKE ON YOU!"] = "SNAKE ON YOU!",	-- TODO: French translation missing !!!!
+--	["SNAKE ON %s!"] = "SNAKE ON %s!",	-- TODO: French translation missing !!!!
+--	["SNAKE"] = "SNAKE",	-- TODO: French translation missing !!!!
+--	["THORNS DEBUFF"] = "THORNS\nDEBUFF",	-- TODO: French translation missing !!!!
+--	["MARKER North"] = "North",	-- TODO: French translation missing !!!!
+--	["MARKER South"] = "South",	-- TODO: French translation missing !!!!
+--	["MARKER East"] = "East",	-- TODO: French translation missing !!!!
+--	["MARKER West"] = "West",	-- TODO: French translation missing !!!!
 })
 mod:RegisterGermanLocale({
 	-- Unit names.
+	["Essence of Life"] = "Lebensessenz",
+	["Essence of Logic"] = "Logikessenz",
+	["Alphanumeric Hash"] = "Alphanumerische Raute",
+	["Life Force"] = "Lebenskraft",
+	["Mnemesis"] = "Mnemesis",
+	["Visceralus"] = "Viszeralus",
 	-- Datachron messages.
 	-- Cast.
+	["Blinding Light"] = "Blendendes Licht",
+	["Defragment"] = "Defragmentieren",
 	-- Bar and messages.
+--	["Defrag Explosion"] = "Defrag Explosion",	-- TODO: German translation missing !!!!
+--	["~DEFRAG CD"] = "~DEFRAG CD",	-- TODO: German translation missing !!!!
+--	["DEFRAG"] = "DEFRAG",	-- TODO: German translation missing !!!!
+--	["ENRAGE"] = "ENRAGE",	-- TODO: German translation missing !!!!
+--	["No-Healing Debuff!"] = "No-Healing Debuff!",	-- TODO: German translation missing !!!!
+--	["NO HEAL DEBUFF"] = "NO HEAL\nDEBUFF",	-- TODO: German translation missing !!!!
+--	["SNAKE ON YOU!"] = "SNAKE ON YOU!",	-- TODO: German translation missing !!!!
+--	["SNAKE ON %s!"] = "SNAKE ON %s!",	-- TODO: German translation missing !!!!
+--	["SNAKE"] = "SNAKE",	-- TODO: German translation missing !!!!
+--	["THORNS DEBUFF"] = "THORNS\nDEBUFF",	-- TODO: German translation missing !!!!
+--	["MARKER North"] = "North",	-- TODO: German translation missing !!!!
+--	["MARKER South"] = "South",	-- TODO: German translation missing !!!!
+--	["MARKER East"] = "East",	-- TODO: German translation missing !!!!
+--	["MARKER West"] = "West",	-- TODO: German translation missing !!!!
 })
 
 --------------------------------------------------------------------------------

--- a/Modules/ExperimentX89.lua
+++ b/Modules/ExperimentX89.lua
@@ -34,7 +34,8 @@ mod:RegisterFrenchLocale({
 	-- Unit names.
 	["Experiment X-89"] = "Expérience X-89",
 	-- Datachron messages.
-	["Experiment X-89 has placed a bomb"] = "L'expérience X%-89 a posé une bombe sur (.*) !",
+	---- This entry is used with string.match, so the dash in X-89 needs to be escaped.
+--	["Experiment X-89 has placed a bomb"] = "Experiment X%-89 has placed a bomb on (.*)!",	-- TODO: French translation missing !!!!
 	-- Cast.
 	["Shattering Shockwave"] = "Onde de choc dévastatrice",
 	["Repugnant Spew"] = "Crachat répugnant",
@@ -53,15 +54,16 @@ mod:RegisterGermanLocale({
 	-- Unit names.
 	["Experiment X-89"] = "Experiment X-89",
 	-- Datachron messages.
-	["Experiment X-89 has placed a bomb"] = "Experiment X%-89 hat eine Bombe auf (.*)!",
+	---- This entry is used with string.match, so the dash in X-89 needs to be escaped.
+--	["Experiment X-89 has placed a bomb"] = "Experiment X%-89 has placed a bomb on (.*)!",	-- TODO: German translation missing !!!!
 	-- Cast.
 	["Shattering Shockwave"] = "Zerschmetternde Schockwelle",
 	["Repugnant Spew"] = "Widerliches Erbrochenes",
 	["Resounding Shout"] = "Widerhallender Schrei",
 	-- Bar and messages.
+--	["KNOCKBACK !!"] = "KNOCKBACK !!",	-- TODO: German translation missing !!!!
 	["KNOCKBACK"] = "RÜCKSTOß",
-	["KNOCKBACK !!"] = "RÜCKSTOß !!!",
-	["BEAM !!"] = "LASER !!",
+--	["BEAM !!"] = "BEAM !!",	-- TODO: German translation missing !!!!
 	["BEAM"] = "LASER",
 	["SHOCKWAVE"] = "SCHOCKWELLE",
 	["BIG BOMB on YOU !!!"] = "GROßE BOMBE auf DIR !!!",

--- a/Modules/FrostAvalanche.lua
+++ b/Modules/FrostAvalanche.lua
@@ -22,17 +22,27 @@ mod:RegisterEnglishLocale({
 })
 mod:RegisterFrenchLocale({
 	-- Unit names.
-	-- Datachron messages.
-	-- NPCSay messages.
+	["Frost-Boulder Avalanche"] = "Avalanche cryoroc",
 	-- Cast.
+	["Icicle Storm"] = "Tempête de stalactites",
+	["Shatter"] = "Fracasser",
+	["Cyclone"] = "Cyclone",
 	-- Bar and messages.
+--	["CYCLONE SOON"] = "CYCLONE SOON",	-- TODO: French translation missing !!!!
+--	["ICICLE"] = "ICICLE%s"	-- TODO: French translation missing !!!!
+--	["SHATTER"] = "SHATTER%s"	-- TODO: French translation missing !!!!
 })
 mod:RegisterGermanLocale({
 	-- Unit names.
-	-- Datachron messages.
-	-- NPCSay messages.
+	["Frost-Boulder Avalanche"] = "Frostfelsen-Lawine",
 	-- Cast.
+	["Icicle Storm"] = "Eiszapfensturm",
+	["Shatter"] = "Zerschmettern",
+	["Cyclone"] = "Wirbelsturm",
 	-- Bar and messages.
+--	["CYCLONE SOON"] = "CYCLONE SOON",	-- TODO: German translation missing !!!!
+--	["ICICLE"] = "ICICLE%s"	-- TODO: German translation missing !!!!
+--	["SHATTER"] = "SHATTER%s"	-- TODO: German translation missing !!!!
 })
 
 --------------------------------------------------------------------------------

--- a/Modules/Gloomclaw.lua
+++ b/Modules/Gloomclaw.lua
@@ -47,13 +47,15 @@ mod:RegisterFrenchLocale({
 	["Strain Parasite"] = "Parasite de la Souillure",
 	["Gloomclaw Skurge"] = "Skurge serrenox",
 	["Corrupted Fraz"] = "Friz corrompu",
+	["Essence of Logic"] = "Essence de logique",
 	-- Datachron messages.
-	["Gloomclaw is reduced to a weakened state"] = "Serrenox a été affaibli !",
-	["Gloomclaw is vulnerable"] = "Serrenox est vulnérable !",
-	["Gloomclaw is pushed back"] = "Serrenox est repoussé par la purification des essences !",
-	["Gloomclaw is moving forward"] = "Serrenox s'approche pour corrompre davantage d'essences !",
+--	["Gloomclaw is reduced to a weakened state"] = "Gloomclaw is reduced to a weakened state!",	-- TODO: French translation missing !!!!
+--	["Gloomclaw is vulnerable"] = "Gloomclaw is vulnerable!",	-- TODO: French translation missing !!!!
+--	["Gloomclaw is pushed back"] = "Gloomclaw is pushed back by the purification of the essences!",	-- TODO: French translation missing !!!!
+--	["Gloomclaw is moving forward"] = "Gloomclaw is moving forward to corrupt more essences!",	-- TODO: French translation missing !!!!
 	-- Cast.
 	["Rupture"] = "Rupture",
+	["Corrupting Rays"] = "Rayons de corruption",
 	-- Bar and messages.
 	["INTERRUPT %s"] = "INTÉRROMPRE %s",
 	["NEXT RUPTURE"] = "PROCHAINE RUPTURE",
@@ -66,12 +68,38 @@ mod:RegisterFrenchLocale({
 	["RIGHT"] = "DROITE",
 	["TRANSITION"] = "TRANSITION",
 	["MOO PHASE"] = "MOO PHASE",
+--	["BURN HIM HARD"] = "BURN HIM HARD",	-- TODO: French translation missing !!!!
 })
 mod:RegisterGermanLocale({
 	-- Unit names.
+	["Gloomclaw"] = "Düsterklaue",
+	["Corrupted Ravager"] = "Korrumpierter Verwüster",
+--	["Empowered Ravager"] = "Empowered Ravager",	-- TODO: German translation missing !!!!
+	["Strain Parasite"] = "Transmutierten-Parasit",
+	["Gloomclaw Skurge"] = "Düsterklauen-Geißel",
+	["Corrupted Fraz"] = "Korrumpierter Fraz",
+	["Essence of Logic"] = "Logikessenz",
 	-- Datachron messages.
+--	["Gloomclaw is reduced to a weakened state"] = "Gloomclaw is reduced to a weakened state!",	-- TODO: German translation missing !!!!
+--	["Gloomclaw is vulnerable"] = "Gloomclaw is vulnerable!",	-- TODO: German translation missing !!!!
+--	["Gloomclaw is pushed back"] = "Gloomclaw is pushed back by the purification of the essences!",	-- TODO: German translation missing !!!!
+--	["Gloomclaw is moving forward"] = "Gloomclaw is moving forward to corrupt more essences!",	-- TODO: German translation missing !!!!
 	-- Cast.
+	["Rupture"] = "Aufreißen",
+	["Corrupting Rays"] = "Korrumpierende Strahlen",
 	-- Bar and messages.
+--	["INTERRUPT %s"] = "INTERRUPT %s",	-- TODO: German translation missing !!!!
+--	["NEXT RUPTURE"] = "NEXT RUPTURE",	-- TODO: German translation missing !!!!
+--	["~NEXT RUPTURE"] = "~NEXT RUPTURE",	-- TODO: German translation missing !!!!
+--	["FULL CORRUPTION"] = "FULL CORRUPTION",	-- TODO: German translation missing !!!!
+--	["SECTION %u"] = "SECTION %u",	-- TODO: German translation missing !!!!
+--	["[%u] WAVE"] = "[%u] WAVE",	-- TODO: German translation missing !!!!
+--	["FROG %u"] = "FROG %u",	-- TODO: German translation missing !!!!
+--	["LEFT"] = "LEFT",	-- TODO: German translation missing !!!!
+--	["RIGHT"] = "RIGHT",	-- TODO: German translation missing !!!!
+--	["TRANSITION"] = "TRANSITION",	-- TODO: German translation missing !!!!
+--	["MOO PHASE"] = "MOO PHASE",	-- TODO: German translation missing !!!!
+--	["BURN HIM HARD"] = "BURN HIM HARD",	-- TODO: German translation missing !!!!
 })
 
 --------------------------------------------------------------------------------

--- a/Modules/Kuralak.lua
+++ b/Modules/Kuralak.lua
@@ -48,7 +48,17 @@ mod:RegisterFrenchLocale({
 	-- Unit names.
 	["Kuralak the Defiler"] = "Kuralak la Profanatrice",
 	-- Datachron messages.
+--	["Kuralak the Defiler returns to the Archive Core"] = "Kuralak the Defiler returns to the Archive Core",	-- TODO: French translation missing !!!!
+--	["Kuralak the Defiler causes a violent outbreak of corruption"] = "Kuralak the Defiler causes a violent outbreak of corruption",	-- TODO: French translation missing !!!!
+--	["The corruption begins to fester"] = "The corruption begins to fester",	-- TODO: French translation missing !!!!
+--	["has been anesthetized"] = "has been anesthetized",	-- TODO: French translation missing !!!!
 	-- NPCSay messages.
+--	["Through the Strain you will be transformed"] = "Through the Strain you will be transformed",	-- TODO: French translation missing !!!!
+--	["Your form is flawed, but I will make you beautiful"] = "Your form is flawed, but I will make you beautiful",	-- TODO: French translation missing !!!!
+--	["Let the Strain perfect you"] = "Let the Strain perfect you",	-- TODO: French translation missing !!!!
+--	["The Experiment has failed"] = "The Experiment has failed",	-- TODO: French translation missing !!!!
+--	["Join us... become one with the Strain"] = "Join us... become one with the Strain",	-- TODO: French translation missing !!!!
+--	["One of us... you will become one of us"] = "One of us... you will become one of us",	-- TODO: French translation missing !!!!
 	-- Cast.
 	["Vanish into Darkness"] = "Disparaître dans les ténèbres",
 	-- Bar and messages.
@@ -63,17 +73,44 @@ mod:RegisterFrenchLocale({
 	["BERSERK !!"] = "BERSERK !!",
 	["SWITCH TANK"] = "CHANGEMENT TANK",
 	["Switch Tank (%s)"] = "Changement de Tank (%s)",
-	["MARKER north"] = "N",
-	["MARKER south"] = "S",
-	["MARKER east"] = "E",
-	["MARKER west"] = "O",
+--	["MARKER north"] = "N",	-- TODO: French translation missing !!!!
+--	["MARKER south"] = "S",	-- TODO: French translation missing !!!!
+--	["MARKER east"] = "E",	-- TODO: French translation missing !!!!
+--	["MARKER west"] = "W",	-- TODO: French translation missing !!!!
 })
 mod:RegisterGermanLocale({
 	-- Unit names.
+	["Kuralak the Defiler"] = "Kuralak die Schänderin",
 	-- Datachron messages.
+	["Kuralak the Defiler returns to the Archive Core"] = "Kuralak die Schänderin kehrt zum Archivkern zurück",
+	["Kuralak the Defiler causes a violent outbreak of corruption"] = "Kuralak die Schänderin verursacht einen heftigen Ausbruch der Korrumpierung",
+	["The corruption begins to fester"] = "Die Korrumpierung beginnt zu eitern",
+	["has been anesthetized"] = "wurde narkotisiert",
 	-- NPCSay messages.
+	["Through the Strain you will be transformed"] = "Durch die Transformation wirst du",
+	["Your form is flawed, but I will make you beautiful"] = "aber ich werde dich schön machen",
+	["Let the Strain perfect you"] = "Dies ist mein Reich! Daraus gibt es kein Entrinnen ...",
+	["The Experiment has failed"] = "Lass dich von der Transmutation perfektionieren",
+	["Join us... become one with the Strain"] = "Die Transmutation ... Lass dich von ihr verschlingen ...",
+	["One of us... you will become one of us"] = "Einer von uns ...",
 	-- Cast.
+	["Vanish into Darkness"] = "In der Dunkelheit verschwinden",
 	-- Bar and messages.
+	["P2 SOON !"] = "GLEICH PHASE 2 !",
+--	["PHASE 2 !"] = "PHASE 2 !",	-- TODO: German translation missing !!!!
+	["VANISH"] = "VERSCHWINDEN",
+	["Vanish"] = "Verschwinden",
+	["OUTBREAK"] = "AUSBRUCH",
+--	["Outbreak (%s)"] = "Outbreak (%s)",	-- TODO: German translation missing !!!!
+--	["EGGS (%s)"] = "EGGS (%s)",	-- TODO: German translation missing !!!!
+--	["Eggs (%s)"] = "Eggs (%s)",	-- TODO: German translation missing !!!!
+	["BERSERK !!"] = "DAS WARS !!",
+	["SWITCH TANK"] = "TANKWECHSEL",
+--	["Switch Tank (%s)"] = "Switch Tank (%s)",	-- TODO: German translation missing !!!!
+--	["MARKER north"] = "N",	-- TODO: German translation missing !!!!
+--	["MARKER south"] = "S",	-- TODO: German translation missing !!!!
+--	["MARKER east"] = "E",	-- TODO: German translation missing !!!!
+--	["MARKER west"] = "W",	-- TODO: German translation missing !!!!
 })
 
 --------------------------------------------------------------------------------

--- a/Modules/Maelstrom.lua
+++ b/Modules/Maelstrom.lua
@@ -43,15 +43,53 @@ mod:RegisterEnglishLocale({
 })
 mod:RegisterFrenchLocale({
 	-- Unit names.
+	["Wind Wall"] = "Mur de vent",
+--	["Avatus Hologram"] = "Avatus Hologram",	-- TODO: French translation missing !!!!
+	["Weather Station"] = "Station météorologique",
+	["Maelstrom Authority"] = "Contrôleur du Maelstrom",
 	-- Datachron messages.
+--	["The platform trembles"] = "The platform trembles",	-- TODO: French translation missing !!!!
 	-- Cast.
+	["Activate Weather Cycle"] = "Activer cycle climatique",
+	["Ice Breath"] = "Souffle de glace",
+	["Crystallize"] = "Cristalliser",
+	["Typhoon"] = "Typhon",
 	-- Bar and messages.
+--	["[%u] STATION: %s %s"] = "[%u] STATION: %s %s",	-- TODO: French translation missing !!!!
+--	["[%u] STATION"] = "[%u] STATION",	-- TODO: French translation missing !!!!
+--	["ICE BREATH"] = "ICE BREATH",	-- TODO: French translation missing !!!!
+--	["TYPHOON"] = "TYPHOON",	-- TODO: French translation missing !!!!
+--	["JUMP"] = "JUMP",	-- TODO: French translation missing !!!!
+--	["Encounter Start"] = "Encounter Start",	-- TODO: French translation missing !!!!
+--	["NORTH"] = "NORTH",	-- TODO: French translation missing !!!!
+--	["SOUTH"] = "SOUTH",	-- TODO: French translation missing !!!!
+--	["EAST"] = "EAST",	-- TODO: French translation missing !!!!
+--	["WEST"] = "WEST",	-- TODO: French translation missing !!!!
 })
 mod:RegisterGermanLocale({
 	-- Unit names.
+	["Wind Wall"] = "Windwand",
+--	["Avatus Hologram"] = "Avatus Hologram",	-- TODO: German translation missing !!!!
+	["Weather Station"] = "Wetterstation",
+	["Maelstrom Authority"] = "Mahlstromgewalt",
 	-- Datachron messages.
+--	["The platform trembles"] = "The platform trembles",	-- TODO: German translation missing !!!!
 	-- Cast.
+	["Activate Weather Cycle"] = "Wetterzyklus aktivieren",
+	["Ice Breath"] = "Eisatem",
+	["Crystallize"] = "Kristallisieren",
+	["Typhoon"] = "Taifun",
 	-- Bar and messages.
+--	["[%u] STATION: %s %s"] = "[%u] STATION: %s %s",	-- TODO: German translation missing !!!!
+--	["[%u] STATION"] = "[%u] STATION",	-- TODO: German translation missing !!!!
+--	["ICE BREATH"] = "ICE BREATH",	-- TODO: German translation missing !!!!
+--	["TYPHOON"] = "TYPHOON",	-- TODO: German translation missing !!!!
+--	["JUMP"] = "JUMP",	-- TODO: German translation missing !!!!
+--	["Encounter Start"] = "Encounter Start",	-- TODO: German translation missing !!!!
+	["NORTH"] = "N",
+	["SOUTH"] = "S",
+	["EAST"] = "E",
+	["WEST"] = "W",
 })
 
 --------------------------------------------------------------------------------

--- a/Modules/Ohmna.lua
+++ b/Modules/Ohmna.lua
@@ -47,18 +47,70 @@ mod:RegisterEnglishLocale({
 mod:RegisterFrenchLocale({
 	-- Unit names.
 	["Dreadphage Ohmna"] = "Ohmna la Terriphage",
+	["Tentacle of Ohmna"] = "Tentacule d'Ohmna",
+	["Ravenous Maw of the Dreadphage"] = "Gueule vorace de la Terriphage",
 	-- Datachron messages.
-	-- NPCSay messages.
+--	["A plasma leech begins draining"] = "A plasma leech begins draining",	-- TODO: French translation missing !!!!
+--	["Dreadphage Ohmna submerges"] = "Dreadphage Ohmna submerges",	-- TODO: French translation missing !!!!
+--	["Dreadphage Ohmna is bored"] = "Dreadphage Ohmna is bored",	-- TODO: French translation missing !!!!
+--	["The Archives tremble as Dreadphage Ohmna"] = "The Archives tremble as Dreadphage Ohmna",	-- TODO: French translation missing !!!!
+--	["The Archives quake with the furious might"] = "The Archives quake with the furious might",	-- TODO: French translation missing !!!!
+	-- Objectifs.
+--	["North Power Core Energy"] = "North Power Core Energy",	-- TODO: French translation missing !!!!
+--	["South Power Core Energy"] = "South Power Core Energy",	-- TODO: French translation missing !!!!
+--	["East Power Core Energy"] = "East Power Core Energy",	-- TODO: French translation missing !!!!
+--	["West Power Core Energy"] = "West Power Core Energy",	-- TODO: French translation missing !!!!
 	-- Cast.
+	["Erupt"] = "Erupt",
 	["Genetic Torrent"] = "Torrent génétique",
 	-- Bar and messages.
+--	["Next Tentacles"] = "Next Tentacles",	-- TODO: French translation missing !!!!
+	["Tentacles"] = "Tentacule",
+	["P2 SOON !"] = "P2 SOON !",
+--	["P2: TENTACLES"] = "P2: TENTACLES",	-- TODO: French translation missing !!!!
+--	["PHASE 2"] = "PHASE 2",	-- TODO: French translation missing !!!!
+--	["P3 SOON !"] = "P3 SOON !",	-- TODO: French translation missing !!!!
+--	["P3: RAVENOUS"] = "P3: RAVENOUS",	-- TODO: French translation missing !!!!
+--	["P3 REALLY SOON !"] = "P3 REALLY SOON !",	-- TODO: French translation missing !!!!
+--	["PILLAR %u : %u"] = "PILLAR %u : %u",	-- TODO: French translation missing !!!!
+--	["PILLAR %u"] = "PILLAR %u",	-- TODO: French translation missing !!!!
+	["SWITCH TANK"] = "CHANGEMENT TANK",
+--	["BIG SPEW"] = "BIG SPEW",	-- TODO: French translation missing !!!!
+--	["NEXT BIG SPEW"] = "NEXT BIG SPEW",	-- TODO: French translation missing !!!!
 })
 mod:RegisterGermanLocale({
 	-- Unit names.
+	["Dreadphage Ohmna"] = "Schreckensphage Ohmna",
+	["Tentacle of Ohmna"] = "Tentakel von Ohmna",
+	["Ravenous Maw of the Dreadphage"] = "Unersättliches Maul der Schreckensphage",
 	-- Datachron messages.
-	-- NPCSay messages.
+	["A plasma leech begins draining"] = "Ein Plasmaegel beginnt, den",
+	["Dreadphage Ohmna submerges"] = "Die Schreckensphage Ohmna taucht in den",
+	["Dreadphage Ohmna is bored"] = "Die Schreckensphage Ohmna langweilt sich",
+	["The Archives tremble as Dreadphage Ohmna"] = "Die Archive beben, als die Tentakeln der Schreckensphage Ohmna um dich herum auftauchen",
+	["The Archives quake with the furious might"] = "Die Archive beben unter der wütenden Macht der Schreckensphage",
+	-- Objectifs.
+	["North Power Core Energy"] = "Nördliche Kraftkernenergie",
+	["South Power Core Energy"] = "Südliche Kraftkernenergie",
+	["East Power Core Energy"] = "Östliche Kraftkernenergie",
+	["West Power Core Energy"] = "Westliche Kraftkernenergie",
 	-- Cast.
+	["Erupt"] = "Ausbrechen",
+	["Genetic Torrent"] = "Genetische Strömung",
 	-- Bar and messages.
+	["Next Tentacles"] = "NÄCHSTE TENTAKEL",
+	["Tentacles"] = "TENTAKEL",
+	["P2 SOON !"] = "GLEICH PHASE 2 !",
+--	["P2: TENTACLES"] = "P2: TENTACLES",	-- TODO: German translation missing !!!!
+	["PHASE 2"] = "PHASE 2",
+	["P3 SOON !"] = "GLEICH PHASE 3 !",
+--	["P3: RAVENOUS"] = "P3: RAVENOUS",	-- TODO: German translation missing !!!!
+	["P3 REALLY SOON !"] = "17 % | VORSICHT MIT DAMAGE",
+--	["PILLAR %u : %u"] = "PILLAR %u : %u",	-- TODO: German translation missing !!!!
+--	["PILLAR %u"] = "PILLAR %u",	-- TODO: German translation missing !!!!
+	["SWITCH TANK"] = "TANKWECHSEL",
+	["BIG SPEW"] = "GROßES BRECHEN",
+	["NEXT BIG SPEW"] = "NÄCHSTES GROßES BRECHEN",
 })
 
 

--- a/Modules/PhageCouncil.lua
+++ b/Modules/PhageCouncil.lua
@@ -37,8 +37,10 @@ mod:RegisterFrenchLocale({
 	["Noxmind the Insidious"] = "Toxultime l'Insidieux",
 	["Ersoth Curseform"] = "Ersoth le Maudisseur",
 	-- Datachron messages.
+--	["The Phageborn Convergence begins gathering its power"] = "The Phageborn Convergence begins gathering its power",	-- TODO: French translation missing !!!!
 	-- Cast.
 	["Teleport"] = "Se téléporter",
+	["Channeling Energy"] = "Canaliser l'énergie",
 	-- Bar and messages.
 	["[%u] NEXT P2"] = "[%u] PROCHAINE P2",
 	["P2 : 20 IA"] = "P2 : 20 IA",
@@ -48,9 +50,22 @@ mod:RegisterFrenchLocale({
 })
 mod:RegisterGermanLocale({
 	-- Unit names.
+	["Terax Blightweaver"] = "Terax Brandweber",
+	["Golgox the Lifecrusher"] = "Golgox der Lebenszermalmer",
+	["Fleshmonger Vratorg"] = "Fleischhändler Vratorg",
+	["Noxmind the Insidious"] = "Noxgeist der Hinterlistige",
+	["Ersoth Curseform"] = "Ersoth Fluchform",
 	-- Datachron messages.
+	["The Phageborn Convergence begins gathering its power"] = "Die Konvergenz der Phagengeborenen sammelt ihre Macht",
 	-- Cast.
+	["Teleport"] = "Teleportieren",
+	["Channeling Energy"] = "Energie kanalisieren",
 	-- Bar and messages.
+--	["[%u] NEXT P2"] = "[%u] NEXT P2",	-- TODO: German translation missing !!!!
+	["P2 : 20 IA"] = "P2 : 20x UNTERBRECHEN",
+	["P2 : MINI ADDS"] = "P2 : MINI ADDS",
+	["P2 : SUBDUE"] = "P2 : ENTWAFFNEN",
+	["P2 : PILLARS"] = "P2 : GENERATOREN",
 })
 
 

--- a/Modules/Phagemaw.lua
+++ b/Modules/Phagemaw.lua
@@ -26,14 +26,22 @@ mod:RegisterFrenchLocale({
 	["Phage Maw"] = "Phagegueule",
 	["Detonation Bomb"] = "Bombe à détonateur",
 	-- Datachron messages.
+--	["The augmented shield has been destroyed"] = "The augmented shield has been destroyed",	-- TODO: French translation missing !!!!
+--	["Phage Maw begins charging an orbital strike"] = "Phage Maw begins charging an orbital strike",	-- TODO: French translation missing !!!!
 	-- Bar and messages.
 	["Bomb %u"] = "Bombe %u",
 	["BOOOM !"] = "BOOOM !",
 })
 mod:RegisterGermanLocale({
 	-- Unit names.
+	["Phage Maw"] = "Phagenschlund",
+	["Detonation Bomb"] = "Sprengbombe",
 	-- Datachron messages.
+	["The augmented shield has been destroyed"] = "Der augmentierte Schild wurde zerstört",
+	["Phage Maw begins charging an orbital strike"] = "Phagenschlund beginnt einen Orbitalschlag aufzuladen",
 	-- Bar and messages.
+--	["Bomb %u"] = "Bomb %u",	-- TODO: German translation missing !!!!
+	["BOOOM !"] = "BOOOM !",
 })
 
 --------------------------------------------------------------------------------

--- a/Modules/Prototypes.lua
+++ b/Modules/Prototypes.lua
@@ -40,6 +40,10 @@ mod:RegisterFrenchLocale({
 	["Phagetech Protector"] = "Protecteur technophage",
 	["Phagetech Fabricator"] = "Fabricant technophage",
 	-- Datachron messages.
+--	["Phagetech Commander is now active!"] = "Phagetech Commander is now active!",	-- TODO: French translation missing !!!!
+--	["Phagetech Augmentor is now active!"] = "Phagetech Augmentor is now active!",	-- TODO: French translation missing !!!!
+--	["Phagetech Protector is now active!"] = "Phagetech Protector is now active!",	-- TODO: French translation missing !!!!
+--	["Phagetech Fabricator is now active!"] = "Phagetech Fabricator is now active!",	-- TODO: French translation missing !!!!
 	-- Cast.
 	["Summon Repairbot"] = "Déployer Bricobot",
 	["Summon Destructobot"] = "Déployer Destructobot",
@@ -54,10 +58,26 @@ mod:RegisterFrenchLocale({
 })
 mod:RegisterGermanLocale({
 	-- Unit names.
+	["Phagetech Commander"] = "Phagentech-Kommandant",
+	["Phagetech Augmentor"] = "Phagentech-Augmentor",
+	["Phagetech Protector"] = "Phagentech-Protektor",
+	["Phagetech Fabricator"] = "Phagentech-Fabrikant",
 	-- Datachron messages.
-	-- NPCSay messages.
+	["Phagetech Commander is now active!"] = "Phagentech-Kommandant ist jetzt aktiv",
+	["Phagetech Augmentor is now active!"] = "Phagentech-Augmentor ist jetzt aktiv",
+	["Phagetech Protector is now active!"] = "Phagentech-Protektor ist jetzt aktiv",
+	["Phagetech Fabricator is now active!"] = "Phagentech-Fabrikant ist jetzt aktiv",
 	-- Cast.
+	["Summon Repairbot"] = "Reparaturbot herbeirufen",
+	["Summon Destructobot"] = "Destruktobot herbeirufen",
 	-- Bar and messages.
+	["[1] LINK + KICK"] = "[1] VERBINDUNG + KICK",
+	["[2] TP + CROIX + BOTS"] = "[2] FARBEN + KREUZ + REPARATURBOTS",
+	["[3] SINGULARITY + VAGUE"] = "[3] SINGULARITÄT + WELLEN",
+	["[4] SOAK + BOTS"] = "[4] KREISE + DESTRUKTOBOTS",
+--	["BOTS !!"] = "BOTS !!",	-- TODO: German translation missing !!!!
+	["BERSERK"] = "BERSERK",
+	["Singularity"] = "SINGULARITÄT",
 })
 
 --------------------------------------------------------------------------------

--- a/Modules/SystemDaemons.lua
+++ b/Modules/SystemDaemons.lua
@@ -61,15 +61,95 @@ mod:RegisterEnglishLocale({
 })
 mod:RegisterFrenchLocale({
 	-- Unit names.
+	["Binary System Daemon"] = "Daemon 2.0",
+	["Null System Daemon"] = "Daemon 1.0",
+	["Brute Force Algorithm"] = "Algorithme de force brute",
+	["Encryption Program"] = "Programme de cryptage",
+	["Radiation Dispersion Unit"] = "Unité de dispersion de radiations",
+	["Defragmentation Unit"] = "Unité de défragmentation",
+	["Extermination Sequence"] = "Séquence d'extermination",
+	["Data Compiler"] = "Compilateur de données",
+	["Viral Diffusion Inhibitor"] = "Inhibiteur de diffusion virale",
+	["Enhancement Module"] = "Module d'amélioration",
+	["Conduction Unit Mk. I"]  = "Unité de conductivité v1",
+	["Conduction Unit Mk. II"]  = "Unité de conductivité v2",
+--	["Conduction Unit Mk. III"]  = "Conduction Unit Mk. III",	-- TODO: French translation missing !!!!
+	["Infinite Generator Core"] = "Noyau du générateur d'infinité",
+	["Recovery Protocol"] = "Protocole de récupération",
 	-- Datachron messages.
+	["INVALID SIGNAL. DISCONNECTING"] = "SIGNAL INCORRECT.",
+	["COMMENCING ENHANCEMENT SEQUENCE"] = "DÉBUT DE LA SEQUENCE D'AMÉLIORATION",
 	-- Cast.
+	["Repair Sequence"] = "Séquence de réparation",
+	["Power Surge"] = "Afflux d'énergie",
+	["Black IC"] = "CI noir",
 	-- Bar and messages.
+--	["[%u] Probe"] = "[%u] Probe",	-- TODO: French translation missing !!!!
+	["[%u] WAVE"] = "[%u] WAVE",
+--	["[%u] MINIBOSS"] = "[%u] MINIBOSS",	-- TODO: French translation missing !!!!
+--	["MARKER north"] = "N",	-- TODO: French translation missing !!!!
+--	["MARKER south"] = "S",	-- TODO: French translation missing !!!!
+	["P2 SOON !"] = "P2 SOON !",
+	["PHASE 2 !"] = "PHASE 2 !",
+--	["INTERRUPT NORTH"] = "INTERRUPT NORTH",	-- TODO: French translation missing !!!!
+--	["INTERRUPT SOUTH"] = "INTERRUPT SOUTH",	-- TODO: French translation missing !!!!
+--	["AIDDDDDDDS !"] = "AIDDDDDDDS !",	-- TODO: French translation missing !!!!
+--	["PURGE - %s"] = "PURGE - %s",	-- TODO: French translation missing !!!!
+--	["INTERRUPT !"] = "INTERRUPT !",	-- TODO: French translation missing !!!!
+--	["INTERRUPT HEAL!"] = "INTERRUPT HEAL!",	-- TODO: French translation missing !!!!
+--	["BLACK IC"] = "BLACK IC",	-- TODO: French translation missing !!!!
+--	["HEAL"] = "HEAL",	-- TODO: French translation missing !!!!
+--	["PURGE ON YOU"] = "PURGE ON YOU",	-- TODO: French translation missing !!!!
+--	["Probe Spawn"] = "Probe Spawn",	-- TODO: French translation missing !!!!
+--	["DISCONNECT (%u)"] = "DISCONNECT (%u)",	-- TODO: French translation missing !!!!
+--	["YOU ARE NEXT ON NORTH !"] = "YOU ARE NEXT ON NORTH !",	-- TODO: French translation missing !!!!
+--	["YOU ARE NEXT ON SOUTH !"] = "YOU ARE NEXT ON SOUTH !",	-- TODO: French translation missing !!!!
 })
 mod:RegisterGermanLocale({
 	-- Unit names.
+	["Binary System Daemon"] = "Binärsystem-Dämon",
+	["Null System Daemon"] = "Nullsystem-Dämon",
+	["Brute Force Algorithm"] = "Brachialgewalt-Algorithmus",
+	["Encryption Program"] = "Verschlüsselungsprogramm",
+	["Radiation Dispersion Unit"] = "Strahlungsverteilungseinheit",
+	["Defragmentation Unit"] = "Defragmentierungseinheit",
+	["Extermination Sequence"] = "Vernichtungssequenz",
+	["Data Compiler"] = "Datenkompilierer",
+	["Viral Diffusion Inhibitor"] = "Virushemmstoff",
+	["Enhancement Module"] = "Verbesserungsmodul",
+	["Conduction Unit Mk. I"]  = "Leistungseinheit V1",
+	["Conduction Unit Mk. II"]  = "Leistungseinheit V2",
+--	["Conduction Unit Mk. III"]  = "Conduction Unit Mk. III",	-- TODO: German translation missing !!!!
+--	["Infinite Generator Core"] = "Infinite Generator Core",	-- TODO: German translation missing !!!!
+	["Recovery Protocol"] = "Wiederherstellungsprotokoll",
 	-- Datachron messages.
+--	["INVALID SIGNAL. DISCONNECTING"] = "INVALID SIGNAL. DISCONNECTING",	-- TODO: German translation missing !!!!
+--	["COMMENCING ENHANCEMENT SEQUENCE"] = "COMMENCING ENHANCEMENT SEQUENCE",	-- TODO: German translation missing !!!!
 	-- Cast.
+	["Repair Sequence"] = "Reparatursequenz",
+	["Power Surge"] = "Energieschweller",
+	["Black IC"] = "Glatteis",
 	-- Bar and messages.
+--	["[%u] Probe"] = "[%u] Probe",	-- TODO: German translation missing !!!!
+--	["[%u] WAVE"] = "[%u] WAVE",	-- TODO: German translation missing !!!!
+--	["[%u] MINIBOSS"] = "[%u] MINIBOSS",	-- TODO: German translation missing !!!!
+--	["MARKER north"] = "N",	-- TODO: German translation missing !!!!
+--	["MARKER south"] = "S",	-- TODO: German translation missing !!!!
+	["P2 SOON !"] = "GLEICH PHASE 2 !",
+--	["PHASE 2 !"] = "PHASE 2 !",	-- TODO: German translation missing !!!!
+--	["INTERRUPT NORTH"] = "INTERRUPT NORTH",	-- TODO: German translation missing !!!!
+--	["INTERRUPT SOUTH"] = "INTERRUPT SOUTH",	-- TODO: German translation missing !!!!
+--	["AIDDDDDDDS !"] = "AIDDDDDDDS !",	-- TODO: German translation missing !!!!
+--	["PURGE - %s"] = "PURGE - %s",	-- TODO: German translation missing !!!!
+--	["INTERRUPT !"] = "INTERRUPT !",	-- TODO: German translation missing !!!!
+--	["INTERRUPT HEAL!"] = "INTERRUPT HEAL!",	-- TODO: German translation missing !!!!
+--	["BLACK IC"] = "BLACK IC",	-- TODO: German translation missing !!!!
+--	["HEAL"] = "HEAL",	-- TODO: German translation missing !!!!
+--	["PURGE ON YOU"] = "PURGE ON YOU",	-- TODO: German translation missing !!!!
+--	["Probe Spawn"] = "Probe Spawn",	-- TODO: German translation missing !!!!
+--	["DISCONNECT (%u)"] = "DISCONNECT (%u)",	-- TODO: German translation missing !!!!
+--	["YOU ARE NEXT ON NORTH !"] = "YOU ARE NEXT ON NORTH !",	-- TODO: German translation missing !!!!
+--	["YOU ARE NEXT ON SOUTH !"] = "YOU ARE NEXT ON SOUTH !",	-- TODO: German translation missing !!!!
 })
 
 --------------------------------------------------------------------------------

--- a/Modules/VolatilyLattice.lua
+++ b/Modules/VolatilyLattice.lua
@@ -37,19 +37,48 @@ mod:RegisterFrenchLocale({
 	["Avatus"] = "Avatus",
 	["Obstinate Logic Wall"] = "Mur de logique obstiné",
 	["Data Devourer"] = "Dévoreur de données",
+--	["Big Red Button"] = "Big Red Button",	-- TODO: French translation missing !!!!
 	-- Datachron messages.
-	["Avatus prepares to delete all"] = "Avatus se prépare à effacer toutes les données !",
-	["Secure Sector Enhancement"] = "Les ports d'amélioration de secteur sécurisé ont été activés !",
-	["Vertical Locomotion Enhancement"] = "Les ports d'amélioration de locomotion verticale ont été activés !",
+--	["Avatus sets his focus on [PlayerName]!"] = "Avatus sets his focus on (.*)!",	-- TODO: French translation missing !!!!
+--	["Avatus prepares to delete all"] = "Avatus prepares to delete all data!",	-- TODO: French translation missing !!!!
+--	["Secure Sector Enhancement"] = "The Secure Sector Enhancement Ports have been activated!",	-- TODO: French translation missing !!!!
+--	["Vertical Locomotion Enhancement"] = "The Vertical Locomotion Enhancement Ports have been activated!",	-- TODO: French translation missing !!!!
 	-- Cast.
 	["Null and Void"] = "Caduque",
 	-- Bar and messages.
+--	["P2: SHIELD PHASE"] = "P2: SHIELD PHASE",	-- TODO: French translation missing !!!!
+--	["P2: JUMP PHASE"] = "P2: JUMP PHASE",	-- TODO: French translation missing !!!!
+--	["LASER"] = "LASER",	-- TODO: French translation missing !!!!
+--	["EXPLOSION"] = "EXPLOSION",	-- TODO: French translation missing !!!!
+--	["NEXT BEAM"] = "NEXT BEAM",	-- TODO: French translation missing !!!!
+	["[%u] WAVE"] = "[%u] WAVE",
+--	["BEAM on YOU !!!"] = "BEAM on YOU !!!",	-- TODO: French translation missing !!!!
+--	["[%u] BEAM on %s"] = "[%u] BEAM on %s",	-- TODO: French translation missing !!!!
+--	["BIG CAST"] = "BIG CAST",	-- TODO: French translation missing !!!!
 })
 mod:RegisterGermanLocale({
 	-- Unit names.
+	["Avatus"] = "Avatus",
+	["Obstinate Logic Wall"] = "Hartnäckige Logikmauer",
+	["Data Devourer"] = "Datenverschlinger",
+--	["Big Red Button"] = "Big Red Button",	-- TODO: German translation missing !!!!
 	-- Datachron messages.
+--	["Avatus sets his focus on [PlayerName]!"] = "Avatus sets his focus on (.*)!",	-- TODO: German translation missing !!!!
+--	["Avatus prepares to delete all"] = "Avatus prepares to delete all data!",	-- TODO: German translation missing !!!!
+--	["Secure Sector Enhancement"] = "The Secure Sector Enhancement Ports have been activated!",	-- TODO: German translation missing !!!!
+--	["Vertical Locomotion Enhancement"] = "The Vertical Locomotion Enhancement Ports have been activated!",	-- TODO: German translation missing !!!!
 	-- Cast.
+	["Null and Void"] = "Unordnung und Chaos",
 	-- Bar and messages.
+--	["P2: SHIELD PHASE"] = "P2: SHIELD PHASE",	-- TODO: German translation missing !!!!
+--	["P2: JUMP PHASE"] = "P2: JUMP PHASE",	-- TODO: German translation missing !!!!
+--	["LASER"] = "LASER",	-- TODO: German translation missing !!!!
+--	["EXPLOSION"] = "EXPLOSION",	-- TODO: German translation missing !!!!
+--	["NEXT BEAM"] = "NEXT BEAM",	-- TODO: German translation missing !!!!
+--	["[%u] WAVE"] = "[%u] WAVE",	-- TODO: German translation missing !!!!
+--	["BEAM on YOU !!!"] = "BEAM on YOU !!!",	-- TODO: German translation missing !!!!
+--	["[%u] BEAM on %s"] = "[%u] BEAM on %s",	-- TODO: German translation missing !!!!
+--	["BIG CAST"] = "BIG CAST",	-- TODO: German translation missing !!!!
 })
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
Automatic translations were generated using the raidcore-translator script
(http://github.com/olbat/ws-raidcore-translator).
