### PR TITLE
Fix bug where sName wasn't used in OnUnitCreated for air/life

### DIFF
--- a/Modules/EpAirLife.lua
+++ b/Modules/EpAirLife.lua
@@ -258,7 +258,7 @@ function mod:CheckTwirlTimer()
 	end
 end
 
-function mod:OnUnitStateChanged(unit, bInCombat)
+function mod:OnUnitStateChanged(unit, bInCombat, sName)
 	if unit:GetType() == "NonPlayer" and bInCombat then
 		local eventTime = GameLib.GetGameTime()
 		local playerUnit = GameLib.GetPlayerUnit()


### PR DESCRIPTION
Really minor bugfix ;)
