### PR TITLE
DisplayLine will now use InWorldHudStratum

### DIFF
--- a/DisplayLine.lua
+++ b/DisplayLine.lua
@@ -70,7 +70,7 @@ function DisplayLine.new(xmlDoc)
 
 	self.pixie = {}
 
-	self.wOverlay = GeminiGUI:Create("WorldFixedWindow", tOverlayDef):GetInstance()
+	self.wOverlay = GeminiGUI:Create("WorldFixedWindow", tOverlayDef):GetInstance(nil, "InWorldHudStratum")
 	self.wOverlay:Show(false)
 
 	return self


### PR DESCRIPTION
This prevents drawing lines over UI elements such as UnitFrames, ...
