### PR TITLE
New start encounter mechanism, close #70

### DIFF
--- a/Encounters/BossPrototype.lua
+++ b/Encounters/BossPrototype.lua
@@ -15,25 +15,17 @@ local EncounterPrototype = {}
 ------------------------------------------------------------------------------
 -- Constants
 ------------------------------------------------------------------------------
-local DEBUG = false -- Set to true to get (very spammy) debug messages.
+-- Register state allowed.
+local TRIG__ALL = 1
+local TRIG__ANY = 2
+local TRIG_STATES = {
+    ["ALL"] = TRIG__ALL,
+    ["ANY"] = TRIG__ANY,
+}
 
 ------------------------------------------------------------------------------
 -- Privates
 ------------------------------------------------------------------------------
-local function assertfalse()
-	assert(false)
-end
-
-local function dbg(self, msg)
-	Print(format("[DBG:%s] %s", self.displayName, msg))
-end
-
-local function wipe(t)
-	for k,v in pairs(t) do
-		t[k] = nil
-	end
-end
-
 local function RegisterLocale(tBoss, sLanguage, Locales)
   local GeminiLocale = Apollo.GetPackage("Gemini:Locale-1.0").tPackage
   local sName = "RaidCore_" .. tBoss:GetName()
@@ -48,85 +40,35 @@ end
 ------------------------------------------------------------------------------
 -- Encounter Prototype.
 ------------------------------------------------------------------------------
-function EncounterPrototype:RegisterEnableMob(...)
-	self.EnableMob = { ... }
-end
-
-function EncounterPrototype:RegisterRestrictZone(todrop, ...)
-	self.RestrictZone = { ... }
-end
-
-function EncounterPrototype:RegisterEnableZone(todrop, ...)
-	self.EnableZone = { ... }
-end
-
-function EncounterPrototype:RegisterRestrictEventObjective(todrop, ...)
-	self.RestrictEventObjective = { ... }
-end
-
-function EncounterPrototype:RegisterEnableEventObjective(todrop, ...)
-	self.EnableEventObjective = { ... }
-end
-
-function EncounterPrototype:RegisterEnableBossPair(...)
-	self.EnableBossPair = { ... }
+function EncounterPrototype:RegisterTrigMob(sTrigType, tTrigList)
+    assert(type(tTrigList) == "table")
+    local nTrigType = TRIG_STATES[sTrigType:upper()]
+    assert(nTrigType)
+    self.nTrigType = nTrigType
+    self.EnableMob = tTrigList
 end
 
 function EncounterPrototype:PrepareEncounter()
-	-- Invalid registering functions.
-	self.RegisterEnableMob = assertfalse
-	self.RegisterRestrictZone = assertfalse
-	self.RegisterEnableZone = assertfalse
-	self.RegisterRestrictEventObjective = assertfalse
-	self.RegisterEnableEventObjective = assertfalse
-	self.RegisterEnableBossPair = assertfalse
-
-	local keys = {
-		"EnableMob", "EnableBossPair",
-		"RestrictZone", "EnableZone",
-		"RestrictEventObjective", "EnableEventObjective",
-	}
-	-- Translate all fields.
-	for _, field in next, keys do
-		if self[field] then
-			local tmp = {}
-			-- Global dictionnary or encounter dictionnary.
-			local ref = RaidCore
-			if field == "EnableMob" or field == "EnableBossPair" then
-				ref = self
-			end
-			for _, EnglishKey in next, self[field] do
-				table.insert(tmp, ref.L[EnglishKey])
-			end
-			-- Replace english data by local data.
-			self[field] = tmp
-			-- Do the link with current RaidCore implementation.
-			local handler = RaidCore[("Register%s"):format(field)]
-			handler(RaidCore, self, self[field])
-		end
-	end
-end
-
-function EncounterPrototype:IsBossModule()
-	return true
-end
-
-function EncounterPrototype:OnInitialize()
+    local tmp = {}
+    -- Translate trigger names.
+    if self.EnableMob then
+        -- Replace english data by local data.
+        for _, EnglishKey in next, self.EnableMob do
+            table.insert(tmp, self.L[EnglishKey])
+        end
+    end
+    self.EnableMob = tmp
 end
 
 function EncounterPrototype:OnEnable()
-	if DEBUG then dbg(self, "OnEnable()") end
 	if self.SetupOptions then self:SetupOptions() end
 	if type(self.OnBossEnable) == "function" then self:OnBossEnable() end
 	Apollo.RegisterEventHandler("RAID_WIPE", "OnRaidWipe", self)
-	self.isEngaged = false
 	self.delayedmsg = {}
-	--Print("Enabled Boss Module : " .. self.ModuleName)
 end
 
 function EncounterPrototype:OnDisable()
 	if type(self.OnBossDisable) == "function" then self:OnBossDisable() end
-	self.isEngaged = nil
 	Apollo.RemoveEventHandler("UnitCreated",self)
 	Apollo.RemoveEventHandler("UnitEnteredCombat", self)
 	Apollo.RemoveEventHandler("UnitDestroyed", self)
@@ -141,12 +83,7 @@ function EncounterPrototype:OnDisable()
 	Apollo.RemoveEventHandler("RAID_WIPE", self)
 	Apollo.RemoveEventHandler("RAID_SYNC", self)
 	Apollo.RemoveEventHandler("DEBUFF_APPLIED", self)
-	Print("Unloaded Boss Module : " .. self.ModuleName)
 end
-
---function EncounterPrototype:GetOption(spellId)
---	return self.db.profile[spells[spellId]]
---end
 
 function EncounterPrototype:Reboot(isWipe)
 	-- Reboot covers everything including hard module reboots (clicking the minimap icon)
@@ -157,14 +94,6 @@ function EncounterPrototype:Reboot(isWipe)
 	--end
 	self:Disable()
 	self:Enable()
-end
-
-function EncounterPrototype:Start()
-	if not self.isEngaged then
-		self.isEngaged = true
-		RaidCore:StartCombat(self.ModuleName)
-		Print("Fight started : " .. self.ModuleName)
-	end
 end
 
 function EncounterPrototype:RegisterEnglishLocale(Locales)
@@ -190,9 +119,10 @@ function EncounterPrototype:GetSetting(setting, returnString)
 end
 
 function EncounterPrototype:OnRaidWipe()
-	self.isEngaged = false
 	self:CancelAllTimers()
-	wipe(self.delayedmsg)
+	for k,v in pairs(self.delayedmsg) do
+		t[k] = nil
+	end
 	if type(self.OnWipe) == "function" then self:OnWipe() end
 end
 
@@ -202,12 +132,10 @@ function EncounterPrototype:Tank()
 end
 
 function EncounterPrototype:Msg(key, message, duration, sound, color)
-	if not self.isEngaged then return end
 	RaidCore:AddMsg(key, message, duration, sound, color)
 end
 
 function EncounterPrototype:DelayedMsg(key, delay, message, duration, sound, color)
-	if not self.isEngaged then return end
 	if self.delayedmsg[key] then
 		self:CancelTimer(self.delayedmsg[key])
 		self.delayedmsg[key] = nil
@@ -232,6 +160,31 @@ function EncounterPrototype:GetDistanceBetweenUnits(tUnitFrom, tUnitTo)
 		end
 	end
 	return r
+end
+
+--- Default trigger function to start an encounter.
+-- @param tNames  Names of units without break space.
+-- @return  Any unit registered can start the encounter.
+function EncounterPrototype:OnTrig(tNames)
+    if next(self.EnableMob) == nil then
+        return false
+    end
+    if self.nTrigType == TRIG__ANY then
+        for _, sMob in next, self.EnableMob do
+            if tNames[sMob] then
+                return true
+            end
+        end
+        return false
+    elseif self.nTrigType == TRIG__ALL then
+        for _, sMob in next, self.EnableMob do
+            if not tNames[sMob] then
+                return false
+            end
+        end
+        return true
+    end
+    return false
 end
 
 ------------------------------------------------------------------------------

--- a/Encounters/DS/Avatus.lua
+++ b/Encounters/DS/Avatus.lua
@@ -3,8 +3,7 @@ local core = Apollo.GetPackage("Gemini:Addon-1.1").tPackage:GetAddon("RaidCore")
 local mod = core:NewEncounter("Avatus", 52, 98, 104)
 if not mod then return end
 
-mod:RegisterEnableMob("Avatus")
-mod:RegisterRestrictZone("Avatus", "The Oculus")
+mod:RegisterTrigMob("ANY", { "Avatus" })
 mod:RegisterEnglishLocale({
 	-- Unit names.
 	["Avatus"] = "Avatus",
@@ -249,13 +248,7 @@ end
 function mod:OnUnitCreated(unit, sName)
 	local eventTime = GameLib.GetGameTime()
 	--Print(eventTime .. " " .. sName .. " spawned")
-	if sName == self.L["Avatus"] then
-		core:AddUnit(unit)
-		core:WatchUnit(unit)
-		if mod:GetSetting("LineCleaveBoss") then
-			core:AddPixie(unit:GetId(), 2, unit, nil, "Green", 10, 22, 0)
-		end
-	elseif sName == self.L["Holo Hand"] then
+	if sName == self.L["Holo Hand"] then
 		--Print(eventTime .. " Holo hand Spawned")
 		local unitId = unit:GetId()
 		core:AddUnit(unit)
@@ -462,7 +455,6 @@ function mod:OnUnitStateChanged(unit, bInCombat, sName)
 	if unit:GetType() == "NonPlayer" and bInCombat then
 		if sName == self.L["Avatus"] and not encounter_started then
 			local eventTime = GameLib.GetGameTime()
-			self:Start()
 			encounter_started = true
 			phase2warn, phase2 = false, false
 			phase2_blueroom = false
@@ -476,7 +468,9 @@ function mod:OnUnitStateChanged(unit, bInCombat, sName)
 			strMyName = GameLib.GetPlayerUnit():GetName()
 			core:AddUnit(unit)
 			core:WatchUnit(unit)
-			core:StartScan()
+			if mod:GetSetting("LineCleaveBoss") then
+				core:AddPixie(unit:GetId(), 2, unit, nil, "Green", 10, 22, 0)
+			end
 
 			core:AddBar("OBBEAM", self.L["Obliteration Beam"], obliteration_beam_timer, mod:GetSetting("SoundObliterationBeam"))
 			core:AddBar("GGRID", self.L["~Gun Grid"], gungrid_timer, mod:GetSetting("SoundGunGrid"))

--- a/Encounters/DS/DSFireWing.lua
+++ b/Encounters/DS/DSFireWing.lua
@@ -7,7 +7,7 @@ local core = Apollo.GetPackage("Gemini:Addon-1.1").tPackage:GetAddon("RaidCore")
 local mod = core:NewEncounter("DSFireWing", 52, 98, 110)
 if not mod then return end
 
-mod:RegisterEnableMob("Warmonger Agratha", "Warmonger Talarii", "Grand Warmonger Tar'gresh")
+mod:RegisterTrigMob("ANY", { "Warmonger Agratha", "Warmonger Talarii", "Grand Warmonger Tar'gresh" })
 mod:RegisterEnglishLocale({
 	-- Unit names.
 	["Warmonger Agratha"] = "Warmonger Agratha",
@@ -157,28 +157,22 @@ end
 function mod:OnUnitStateChanged(unit, bInCombat, sName)
 	if unit:GetType() == "NonPlayer" and bInCombat then
 		if sName == self.L["Warmonger Agratha"] then
-			self:Start()
 			prev, first = 0, true
 			boss = sName
 			core:AddUnit(unit)
 			core:WatchUnit(unit)
 			core:RaidDebuff()
-			core:StartScan()
 			core:AddBar("BOMB", self.L["BOMB"], 23)
 		elseif sName == self.L["Warmonger Talarii"] then
-			self:Start()
 			prev = 0
 			boss = sName
 			core:AddUnit(unit)
 			core:WatchUnit(unit)
 			core:RaidDebuff()
-			core:StartScan()
 			core:AddBar("KNOCK", self.L["KNOCKBACK"], 23)
 		elseif sName == self.L["Grand Warmonger Tar'gresh"] then
-			self:Start()
 			core:AddUnit(unit)
 			core:WatchUnit(unit)
-			core:StartScan()
 			core:AddBar("STORM", self.L["METEOR STORM"], 26, 1)
 		end
 	end

--- a/Encounters/DS/DSFrostWing.lua
+++ b/Encounters/DS/DSFrostWing.lua
@@ -7,7 +7,7 @@ local core = Apollo.GetPackage("Gemini:Addon-1.1").tPackage:GetAddon("RaidCore")
 local mod = core:NewEncounter("DSFrostWing", 52, 98, 109)
 if not mod then return end
 
-mod:RegisterEnableMob("Frost-Boulder Avalanche", "Frostbringer Warlock")
+mod:RegisterTrigMob("ANY", { "Frost-Boulder Avalanche", "Frostbringer Warlock" })
 
 --------------------------------------------------------------------------------
 -- Locals
@@ -122,15 +122,12 @@ end
 function mod:OnUnitStateChanged(unit, bInCombat, sName)
 	if unit:GetType() == "NonPlayer" and bInCombat then
 		if sName == self.L["Frost-Boulder Avalanche"] then
-			self:Start()
 			icicleSpell = false
 			core:AddUnit(unit)
 			core:WatchUnit(unit)
 			core:AddBar("ICICLE", "~" .. self.L["ICICLE"], 17)
 			core:AddBar("SHATTER", "~" .. self.L["Shatter"]:upper(), 30)
-			core:StartScan()
 		elseif sName == self.L["Frostbringer Warlock"] then
-			self:Start()
 			core:AddUnit(unit)
 			core:AddBar("WAVES", self.L["FROST WAVE"], 30)
 		end

--- a/Encounters/DS/DSLogicWing.lua
+++ b/Encounters/DS/DSLogicWing.lua
@@ -7,7 +7,9 @@ local core = Apollo.GetPackage("Gemini:Addon-1.1").tPackage:GetAddon("RaidCore")
 local mod = core:NewEncounter("DSLogicWing", 52, 98, 111)
 if not mod then return end
 
-mod:RegisterEnableMob("Hyper-Accelerated Skeledroid", "Augmented Herald of Avatus", "Abstract Augmentation Algorithm")
+mod:RegisterTrigMob("ANY", {
+    "Hyper-Accelerated Skeledroid", "Augmented Herald of Avatus",
+    "Abstract Augmentation Algorithm" })
 mod:RegisterEnglishLocale({
 	-- Unit names.
 	["Conjured Fire Bomb"] = "Conjured Fire Bomb",
@@ -142,28 +144,22 @@ end
 function mod:OnUnitEnteredCombat(unit, bInCombat, sName)
 	if unit:GetType() == "NonPlayer" and bInCombat then
 		if sName == self.L["Abstract Augmentation Algorithm"] then
-			self:Start()
 			prevInt = ""
 			castCount = 1
 			core:AddUnit(unit)
 			--core:WatchUnit(unit)
 			core:RaidDebuff()
-			core:StartScan()
 			core:AddBar("DATA", self.L["[%u] INTERRUPT"]:format(castCount), 7)
 			core:AddBar("EMPOWER", self.L["EMPOWER"]:format(""), 30, 1)
 		elseif sName == self.L["Quantum Processing Unit"] then
-			self:Start()
 			core:AddUnit(unit)
 			core:MarkUnit(unit)
 		elseif sName == self.L["Hyper-Accelerated Skeledroid"] then
-			self:Start()
 			core:AddUnit(unit)
 			core:AddBar("BERSERK", self.L["BERSERK"], 180, 1)
 		elseif sName == self.L["Augmented Herald of Avatus"] then
-			self:Start()
 			core:AddUnit(unit)
 			core:WatchUnit(unit)
-			core:StartScan()
 			core:AddBar("CUBE", self.L["CUBE SMASH"], 8)
 		end
 	end

--- a/Encounters/DS/EpAirEarth.lua
+++ b/Encounters/DS/EpAirEarth.lua
@@ -7,9 +7,7 @@ local core = Apollo.GetPackage("Gemini:Addon-1.1").tPackage:GetAddon("RaidCore")
 local mod = core:NewEncounter("EpAirEarth", 52, 98, 117)
 if not mod then return end
 
---mod:RegisterEnableMob("Megalith")
-mod:RegisterEnableBossPair("Megalith", "Aileron")
-mod:RegisterRestrictZone("EpAirEarth", "Elemental Vortex Alpha", "Elemental Vortex Beta", "Elemental Vortex Delta")
+mod:RegisterTrigMob("ALL", { "Megalith", "Aileron" })
 mod:RegisterEnglishLocale({
 	-- Unit names.
 	["Megalith"] = "Megalith",
@@ -70,7 +68,6 @@ local startTime
 --------------------------------------------------------------------------------
 -- Initialization
 --
-
 function mod:OnBossEnable()
 	Print(("Module %s loaded"):format(mod.ModuleName))
 	Apollo.RegisterEventHandler("RC_UnitCreated", "OnUnitCreated", self)
@@ -142,7 +139,6 @@ function mod:OnUnitStateChanged(unit, bInCombat, sName)
 			core:WatchUnit(unit)
 			core:MarkUnit(unit, nil, self.L["EARTH"])
 		elseif sName == self.L["Aileron"] then
-			self:Start()
 			prev = 0
 			midphase = false
 			if mod:GetSetting("LineCleaveAileron") then
@@ -152,8 +148,6 @@ function mod:OnUnitStateChanged(unit, bInCombat, sName)
 			core:AddBar("TORNADO", self.L["~Tornado Spawn"], 16, mod:GetSetting("SoundTornadoCountdown"))
 			core:AddUnit(unit)
 			core:WatchUnit(unit)
-			core:StartScan()
-			--Print(eventTime .. "FIGHT STARTED")
 		end
 	end
 end

--- a/Encounters/DS/EpAirLife.lua
+++ b/Encounters/DS/EpAirLife.lua
@@ -7,9 +7,7 @@ local core = Apollo.GetPackage("Gemini:Addon-1.1").tPackage:GetAddon("RaidCore")
 local mod = core:NewEncounter("EpAirLife", 52, 98, 119)
 if not mod then return end
 
---mod:RegisterEnableMob("Aileron", "Test")
-mod:RegisterEnableBossPair("Aileron", "Visceralus")
-mod:RegisterRestrictZone("EpAirLife", "Elemental Vortex Alpha", "Elemental Vortex Beta", "Elemental Vortex Delta")
+mod:RegisterTrigMob("ALL", { "Aileron", "Visceralus" })
 mod:RegisterEnglishLocale({
 	-- Unit names.
 	["Visceralus"] = "Visceralus",
@@ -99,7 +97,6 @@ local twirlCount = 0
 --------------------------------------------------------------------------------
 -- Initialization
 --
-
 function mod:OnBossEnable()
 	Print(("Module %s loaded"):format(mod.ModuleName))
 	Apollo.RegisterEventHandler("RC_UnitCreated", "OnUnitCreated", self)
@@ -270,11 +267,9 @@ function mod:OnUnitStateChanged(unit, bInCombat, sName)
 				core:AddPixie(unit:GetId(), 2, unit, nil, "Red", 10, 30, 0)
 			end
 		elseif sName == self.L["Visceralus"] then
-			self:Start()
 			core:AddUnit(unit)
 			core:WatchUnit(unit)
 			core:RaidDebuff()
-			core:StartScan()
 
 			last_thorns = 0
 			last_twirl = 0

--- a/Encounters/DS/EpAirWater.lua
+++ b/Encounters/DS/EpAirWater.lua
@@ -7,9 +7,7 @@ local core = Apollo.GetPackage("Gemini:Addon-1.1").tPackage:GetAddon("RaidCore")
 local mod = core:NewEncounter("EpAirWater", 52, 98, 118)
 if not mod then return end
 
---mod:RegisterEnableMob("Hydroflux")
-mod:RegisterEnableBossPair("Hydroflux", "Aileron")
-mod:RegisterRestrictZone("EpAirWater", "Elemental Vortex Alpha", "Elemental Vortex Beta", "Elemental Vortex Delta")
+mod:RegisterTrigMob("ALL", { "Hydroflux", "Aileron" })
 mod:RegisterEnglishLocale({
 	-- Unit names.
 	["Hydroflux"] = "Hydroflux",
@@ -72,7 +70,6 @@ local CheckTwirlTimer = nil
 --------------------------------------------------------------------------------
 -- Initialization
 --
-
 function mod:OnBossEnable()
 	Print(("Module %s loaded"):format(mod.ModuleName))
 	Apollo.RegisterEventHandler("RC_UnitStateChanged", "OnUnitStateChanged", self)
@@ -178,7 +175,6 @@ function mod:OnUnitStateChanged(unit, bInCombat, sName)
 			core:WatchUnit(unit)
 			core:UnitBuff(unit)
 		elseif sName == self.L["Aileron"] then
-			self:Start()
 			mooCount = 0
 			phase2 = false
 			twirl_units = {}
@@ -187,7 +183,6 @@ function mod:OnUnitStateChanged(unit, bInCombat, sName)
 			core:UnitBuff(unit)
 			core:UnitDebuff(playerUnit)
 			core:RaidDebuff()
-			core:StartScan()
 			core:AddBar("MIDPHASE", self.L["Middle Phase"], 60, mod:GetSetting("SoundMidphase"))
 			core:AddBar("TOMB", self.L["~Frost Tombs"], 30, mod:GetSetting("SoundFrostTombs"))
 

--- a/Encounters/DS/EpFireLife.lua
+++ b/Encounters/DS/EpFireLife.lua
@@ -7,9 +7,7 @@ local core = Apollo.GetPackage("Gemini:Addon-1.1").tPackage:GetAddon("RaidCore")
 local mod = core:NewEncounter("EpFireLife", 52, 98, 119)
 if not mod then return end
 
---mod:RegisterEnableMob("Visceralus")
-mod:RegisterEnableBossPair("Visceralus", "Pyrobane")
-mod:RegisterRestrictZone("EpFireLife", "Elemental Vortex Alpha", "Elemental Vortex Beta", "Elemental Vortex Delta")
+mod:RegisterTrigMob("ALL", { "Visceralus", "Pyrobane" })
 mod:RegisterEnglishLocale({
 	-- Unit names.
 	["Visceralus"] = "Visceralus",
@@ -68,7 +66,6 @@ local CheckRootTimer = nil
 --------------------------------------------------------------------------------
 -- Initialization
 --
-
 function mod:OnBossEnable()
 	Print(("Module %s loaded"):format(mod.ModuleName))
 	Apollo.RegisterEventHandler("RC_UnitStateChanged", "OnUnitStateChanged", self)
@@ -185,14 +182,12 @@ function mod:OnUnitStateChanged(unit, bInCombat, sName)
 			core:AddUnit(unit)
 			core:WatchUnit(unit)
 		elseif sName == self.L["Pyrobane"] then
-			self:Start()
 			rooted_units = {}
 			CheckRootTimer = nil
 			uPlayer = GameLib.GetPlayerUnit()
 			strMyName = uPlayer:GetName()
 			core:AddUnit(unit)
 			core:RaidDebuff()
-			core:StartScan()
 			core:AddBar("MID", self.L["MIDPHASE"], 90)
 		end
 	end

--- a/Encounters/DS/EpFireWater.lua
+++ b/Encounters/DS/EpFireWater.lua
@@ -7,9 +7,7 @@ local core = Apollo.GetPackage("Gemini:Addon-1.1").tPackage:GetAddon("RaidCore")
 local mod = core:NewEncounter("EpFireWater", 52, 98, 118)
 if not mod then return end
 
---mod:RegisterEnableMob("Hydroflux")
-mod:RegisterEnableBossPair("Hydroflux", "Pyrobane")
-mod:RegisterRestrictZone("EpFireWater", "Elemental Vortex Alpha", "Elemental Vortex Beta", "Elemental Vortex Delta")
+mod:RegisterTrigMob("ALL", { "Hydroflux", "Pyrobane" })
 mod:RegisterEnglishLocale({
 	-- Unit names.
 	["Hydroflux"] = "Hydroflux",
@@ -98,7 +96,6 @@ local frostbomb_players = {}
 --------------------------------------------------------------------------------
 -- Initialization
 --
-
 function mod:OnBossEnable()
 	Print(("Module %s loaded"):format(mod.ModuleName))
 	Apollo.RegisterEventHandler("RC_UnitCreated", "OnUnitCreated", self)
@@ -275,7 +272,6 @@ function mod:OnUnitStateChanged(unit, bInCombat, sName)
 				core:AddPixie(unitId .. "_2", 2, unit, nil, "Yellow", 3, 7, 180)
 			end
 		elseif sName == self.L["Pyrobane"] then
-			self:Start()
 			uPlayer = GameLib.GetPlayerUnit()
 			strMyName = uPlayer:GetName()
 			groupCount = 1
@@ -285,7 +281,6 @@ function mod:OnUnitStateChanged(unit, bInCombat, sName)
 			core:AddUnit(unit)
 			core:RaidDebuff()
 			core:AddBar("BOMBS", self.L["BOMBS"], 30)
-			core:StartScan()
 		end
 	end
 end

--- a/Encounters/DS/EpLogicEarth.lua
+++ b/Encounters/DS/EpLogicEarth.lua
@@ -14,8 +14,7 @@ local core = Apollo.GetPackage("Gemini:Addon-1.1").tPackage:GetAddon("RaidCore")
 local mod = core:NewEncounter("EpLogicEarth", 52, 98, 117)
 if not mod then return end
 
-mod:RegisterEnableBossPair("Megalith", "Mnemesis")
-mod:RegisterRestrictZone("EpLogicEarth", "Elemental Vortex Alpha", "Elemental Vortex Beta", "Elemental Vortex Delta")
+mod:RegisterTrigMob("ALL", { "Megalith", "Mnemesis" })
 mod:RegisterEnglishLocale({
 	-- Unit names.
 	["Megalith"] = "Megalith",
@@ -97,6 +96,7 @@ local pilarCount = 0
 -- Initialization
 ----------------------------------------------------------------------------------------------------
 function mod:OnBossEnable()
+	Apollo.RegisterEventHandler("RC_UnitCreated", "OnUnitCreated", self)
 	Apollo.RegisterEventHandler("RC_UnitDestroyed", "OnUnitDestroyed", self)
 	Apollo.RegisterEventHandler("RC_UnitStateChanged", "OnUnitStateChanged", self)
 	Apollo.RegisterEventHandler("SPELL_CAST_START", "OnSpellCastStart", self)
@@ -155,7 +155,6 @@ function mod:OnUnitStateChanged(unit, bInCombat, sName)
 		if sName == self.L["Megalith"] then
 			core:AddUnit(unit)
 		elseif sName == self.L["Mnemesis"] then
-			self:Start()
 			_Previous_Defragment_time = 0
 			pilarCount = 0
 			core:AddBar("DEFRAG", self.L["DEFRAG"], 10)
@@ -163,7 +162,6 @@ function mod:OnUnitStateChanged(unit, bInCombat, sName)
 			core:AddUnit(unit)
 			core:WatchUnit(unit)
 			core:RaidDebuff()
-			Apollo.RegisterEventHandler("RC_UnitCreated", "OnUnitCreated", self)
 		elseif sName == self.L["Crystalline Matrix"] then
 			pilarCount = pilarCount + 1
 		end

--- a/Encounters/DS/EpLogicLife.lua
+++ b/Encounters/DS/EpLogicLife.lua
@@ -7,8 +7,7 @@ local core = Apollo.GetPackage("Gemini:Addon-1.1").tPackage:GetAddon("RaidCore")
 local mod = core:NewEncounter("EpLogicLife", 52, 98, 119)
 if not mod then return end
 
-mod:RegisterEnableBossPair("Mnemesis", "Visceralus")
-mod:RegisterRestrictZone("EpLogicLife", "Elemental Vortex Alpha", "Elemental Vortex Beta", "Elemental Vortex Delta")
+mod:RegisterTrigMob("ALL", { "Mnemesis", "Visceralus" })
 mod:RegisterEnglishLocale({
 	-- Unit names.
 	["Essence of Life"] = "Essence of Life",
@@ -111,7 +110,6 @@ local midpos = {
 --------------------------------------------------------------------------------
 -- Initialization
 --
-
 function mod:OnBossEnable()
 	Print(("Module %s loaded"):format(mod.ModuleName))
 	Apollo.RegisterEventHandler("RC_UnitStateChanged", "OnUnitStateChanged", self)
@@ -240,14 +238,12 @@ function mod:OnUnitStateChanged(unit, bInCombat, sName)
 				core:AddLine("Visc5", 2, unit, nil, 1, 25, 288)
 			end
 		elseif sName == self.L["Mnemesis"] then
-			self:Start()
 			core:WatchUnit(unit)
 			uPlayer = GameLib.GetPlayerUnit()
 			strMyName = uPlayer:GetName()
 			midphase = false
 			core:AddUnit(unit)
 			core:RaidDebuff()
-			core:StartScan()
 			core:AddBar("DEFRAG", self.L["~DEFRAG CD"], 21, mod:GetSetting("SoundDefrag"))
 			core:AddBar("ENRAGE", self.L["ENRAGE"], 480, mod:GetSetting("SoundEnrage"))
 		end

--- a/Encounters/DS/EpLogicWater.lua
+++ b/Encounters/DS/EpLogicWater.lua
@@ -7,8 +7,7 @@ local core = Apollo.GetPackage("Gemini:Addon-1.1").tPackage:GetAddon("RaidCore")
 local mod = core:NewEncounter("EpLogicWater", 52, 98, 118)
 if not mod then return end
 
-mod:RegisterEnableBossPair("Hydroflux", "Mnemesis")
-mod:RegisterRestrictZone("EpLogicWater", "Elemental Vortex Alpha", "Elemental Vortex Beta", "Elemental Vortex Delta")
+mod:RegisterTrigMob("ALL", { "Hydroflux", "Mnemesis" })
 mod:RegisterEnglishLocale({
 	-- Unit names.
 	["Mnemesis"] = "Mnemesis",
@@ -82,7 +81,6 @@ local encounter_started = false
 --------------------------------------------------------------------------------
 -- Initialization
 --
-
 function mod:OnBossEnable()
 	Print(("Module %s loaded"):format(mod.ModuleName))
 	Apollo.RegisterEventHandler("RC_UnitCreated", "OnUnitCreated", self)
@@ -198,7 +196,6 @@ function mod:OnUnitStateChanged(unit, bInCombat, sName)
 			core:AddUnit(unit)
 			core:WatchUnit(unit)
 		elseif sName == self.L["Mnemesis"] then
-			self:Start()
 			uPlayer = GameLib.GetPlayerUnit()
 			strMyName = uPlayer:GetName()
 			midphase = false
@@ -207,7 +204,6 @@ function mod:OnUnitStateChanged(unit, bInCombat, sName)
 			core:RaidDebuff()
 			core:AddUnit(unit)
 			core:WatchUnit(unit)
-			core:StartScan()
 			core:AddBar("MIDPHASE", self.L["Middle Phase"], 75, mod:GetSetting("SoundMidphase"))
 			core:AddBar("PRISON", self.L["Imprison"], 16)
 			core:AddBar("DEFRAG", self.L["Defrag"], 20, mod:GetSetting("SoundDefrag"))

--- a/Encounters/DS/FrostAvalanche.lua
+++ b/Encounters/DS/FrostAvalanche.lua
@@ -7,7 +7,7 @@ local core = Apollo.GetPackage("Gemini:Addon-1.1").tPackage:GetAddon("RaidCore")
 local mod = core:NewEncounter("FrostAvalanche", 52, 98, 109)
 if not mod then return end
 
-mod:RegisterEnableMob("Frost-Boulder Avalanche")
+mod:RegisterTrigMob("ANY", { "Frost-Boulder Avalanche" })
 mod:RegisterEnglishLocale({
 	-- Unit names.
 	["Frost-Boulder Avalanche"] = "Frost-Boulder Avalanche",
@@ -98,7 +98,6 @@ function mod:OnUnitStateChanged(unit, bInCombat, sName)
 			icicleSpell = false
 			core:AddUnit(unit)
 			core:WatchUnit(unit)
-			core:StartScan()
 		end
 	end
 end

--- a/Encounters/DS/Gloomclaw.lua
+++ b/Encounters/DS/Gloomclaw.lua
@@ -7,7 +7,7 @@ local core = Apollo.GetPackage("Gemini:Addon-1.1").tPackage:GetAddon("RaidCore")
 local mod = core:NewEncounter("Gloomclaw", 52, 98, 115)
 if not mod then return end
 
-mod:RegisterEnableMob("Gloomclaw")
+mod:RegisterTrigMob("ANY", { "Gloomclaw" })
 mod:RegisterEnglishLocale({
 	-- Unit names.
 	["Gloomclaw"] = "Gloomclaw",
@@ -302,7 +302,6 @@ end
 function mod:OnUnitStateChanged(unit, bInCombat, sName)
 	if unit:GetType() == "NonPlayer" and bInCombat then
 		if sName == self.L["Gloomclaw"] then
-			self:Start()
 			waveCount, ruptCount, prev = 0, 0, 0
 			section = 1
 			first = true
@@ -314,7 +313,6 @@ function mod:OnUnitStateChanged(unit, bInCombat, sName)
 			core:WatchUnit(unit)
 			core:AddBar("RUPTURE", self.L["~NEXT RUPTURE"], 35, mod:GetSetting("SoundRuptureCountdown"))
 			core:AddBar("CORRUPTION", self.L["FULL CORRUPTION"], 106, mod:GetSetting("SoundCorruptionCountdown"))
-			core:StartScan()
 		elseif sName == self.L["Strain Parasite"]
 			or sName == self.L["Gloomclaw Skurge"]
 			or sName == self.L["Corrupted Fraz"] then

--- a/Encounters/DS/Maelstrom.lua
+++ b/Encounters/DS/Maelstrom.lua
@@ -7,7 +7,7 @@ local core = Apollo.GetPackage("Gemini:Addon-1.1").tPackage:GetAddon("RaidCore")
 local mod = core:NewEncounter("Maelstrom", 52, 98, 120)
 if not mod then return end
 
-mod:RegisterEnableMob("Weather Control Station")
+mod:RegisterTrigMob("ANY", { "Maelstrom Authority" })
 
 --------------------------------------------------------------------------------
 -- Locals
@@ -111,11 +111,7 @@ end
 
 function mod:OnUnitCreated(unit, sName)
 	--Print(sName)
-	if sName == self.L["Avatus Hologram"] then
-		self:Start()
-		core:AddBar("JUMP", self.L["Encounter Start"], 8.5, 1)
-		bossPos = {}
-	elseif sName == self.L["Wind Wall"] and mod:GetSetting("LineWindWalls") then
+	if sName == self.L["Wind Wall"] and mod:GetSetting("LineWindWalls") then
 		core:AddPixie(unit:GetId().."_1", 2, unit, nil, "Green", 10, 20, 0)
 		core:AddPixie(unit:GetId().."_2", 2, unit, nil, "Green", 10, 20, 180)
 		--core:AddLine(unit:GetId().."_1", 2, unit, nil, 1, 20, 0)
@@ -173,10 +169,10 @@ end
 function mod:OnUnitStateChanged(unit, bInCombat, sName)
 	if unit:GetType() == "NonPlayer" and bInCombat then
 		if sName == self.L["Maelstrom Authority"] then
+			bossPos = {}
 			stationCount = 0
 			core:AddUnit(unit)
 			core:WatchUnit(unit)
-			core:StartScan()
 			if mod:GetSetting("LineCleaveBoss") then
 				core:AddPixie(unit:GetId(), 2, unit, nil, "Red", 10, 15, 0)
 			end

--- a/Encounters/DS/SystemDaemons.lua
+++ b/Encounters/DS/SystemDaemons.lua
@@ -7,12 +7,7 @@ local core = Apollo.GetPackage("Gemini:Addon-1.1").tPackage:GetAddon("RaidCore")
 local mod = core:NewEncounter("SystemDaemons", 52, 98, 105)
 if not mod then return end
 
---mod:RegisterEnableBossPair("Binary System Daemon","Null System Daemon")
-mod:RegisterEnableMob("Binary System Daemon","Null System Daemon")
-mod:RegisterRestrictZone("SystemDaemons", "Halls of the Infinite Mind", "Infinite Generator Core", "Lower Infinite Generator Core")
-mod:RegisterEnableZone("SystemDaemons", "Halls of the Infinite Mind", "Infinite Generator Core", "Lower Infinite Generator Core")
-mod:RegisterRestrictEventObjective("SystemDaemons", "Defeat the System Daemons")
-mod:RegisterEnableEventObjective("SystemDaemons", "Defeat the System Daemons")
+mod:RegisterTrigMob("ANY", { "Binary System Daemon", "Null System Daemon" })
 mod:RegisterEnglishLocale({
 	-- Unit names.
 	["Binary System Daemon"] = "Binary System Daemon",
@@ -236,19 +231,6 @@ function mod:OnUnitCreated(unit, sName)
 			end
 			core:AddBar("PROBES", self.L["[%u] Probe"]:format(1), 10)
 		end
-	elseif sName == self.L["Null System Daemon"] or sName == self.L["Binary System Daemon"] then
-		--core:MarkUnit(unit, 0, ("N%s"):format(sdSurgeCount[unit:GetId()] or 0))
-		if sName == self.L["Null System Daemon"] then
-			core:MarkUnit(unit, 0, self.L["MARKER south"])
-		else
-			core:MarkUnit(unit, 0, self.L["MARKER north"])
-		end
-		core:AddUnit(unit)
-		core:WatchUnit(unit)
-	--elseif sName == "Null System Daemon"  then
-		--core:MarkUnit(unit, 0, ("S%s"):format(sdSurgeCount[unit:GetId()] or 0))
-		--core:AddUnit(unit)
-		--core:WatchUnit(unit)
 	elseif sName == self.L["Conduction Unit Mk. I"] then
 		if probeCount == 0 then probeCount = 1 end
 		if GetCurrentSubZoneName():find(self.L["Infinite Generator Core"]) then core:MarkUnit(unit, 1, 1) end
@@ -490,7 +472,11 @@ end
 function mod:OnUnitStateChanged(unit, bInCombat, sName)
 	if unit:GetType() == "NonPlayer" and bInCombat then
 		if sName == self.L["Null System Daemon"] or sName == self.L["Binary System Daemon"] then
-			self:Start()
+			if sName == self.L["Null System Daemon"] then
+				core:MarkUnit(unit, 0, self.L["MARKER south"])
+			else
+				core:MarkUnit(unit, 0, self.L["MARKER north"])
+			end
 			discoCount, sdwaveCount, probeCount = 0, 0, 0
 			phase2warn, phase2 = false, false
 			phase2count = 0
@@ -506,7 +492,6 @@ function mod:OnUnitStateChanged(unit, bInCombat, sName)
 				core:AddBar("DISC", self.L["DISCONNECT (%u)"]:format(discoCount + 1), 41)
 			end
 			core:AddBar("SDWAVE", self.L["[%u] WAVE"]:format(sdwaveCount + 1), 15, mod:GetSetting("SoundWave"))
-			core:StartScan()
 		elseif sName == self.L["Defragmentation Unit"] then
 			if GetCurrentSubZoneName():find("Infinite Generator Core") then
 				core:WatchUnit(unit)

--- a/Encounters/DS/VolatilyLattice.lua
+++ b/Encounters/DS/VolatilyLattice.lua
@@ -7,13 +7,12 @@ local core = Apollo.GetPackage("Gemini:Addon-1.1").tPackage:GetAddon("RaidCore")
 local mod = core:NewEncounter("Lattice", 52, 98, 116)
 if not mod then return end
 
-mod:RegisterEnableMob("Big Red Button")
+mod:RegisterTrigMob("ANY", { "Avatus" })
 mod:RegisterEnglishLocale({
 	-- Unit names.
 	["Avatus"] = "Avatus",
 	["Obstinate Logic Wall"] = "Obstinate Logic Wall",
 	["Data Devourer"] = "Data Devourer",
-	["Big Red Button"] = "Big Red Button",
 	-- Datachron messages.
 	["Avatus sets his focus on [PlayerName]!"] = "Avatus sets his focus on (.*)!",
 	["Avatus prepares to delete all"] = "Avatus prepares to delete all data!",
@@ -37,7 +36,6 @@ mod:RegisterFrenchLocale({
 	["Avatus"] = "Avatus",
 	["Obstinate Logic Wall"] = "Mur de logique obstiné",
 	["Data Devourer"] = "Dévoreur de données",
---	["Big Red Button"] = "Big Red Button",	-- TODO: French translation missing !!!!
 	-- Datachron messages.
 --	["Avatus sets his focus on [PlayerName]!"] = "Avatus sets his focus on (.*)!",	-- TODO: French translation missing !!!!
 	["Avatus prepares to delete all"] = "Avatus se prépare à effacer toutes les données !",
@@ -61,7 +59,6 @@ mod:RegisterGermanLocale({
 	["Avatus"] = "Avatus",
 	["Obstinate Logic Wall"] = "Hartnäckige Logikmauer",
 	["Data Devourer"] = "Datenverschlinger",
---	["Big Red Button"] = "Big Red Button",	-- TODO: German translation missing !!!!
 	-- Datachron messages.
 --	["Avatus sets his focus on [PlayerName]!"] = "Avatus sets his focus on (.*)!",	-- TODO: German translation missing !!!!
 --	["Avatus prepares to delete all"] = "Avatus prepares to delete all data!",	-- TODO: German translation missing !!!!
@@ -118,16 +115,7 @@ function mod:RemoveLaserMark(unit)
 end
 
 function mod:OnUnitDestroyed(unit, sName)
-	if sName == self.L["Big Red Button"] then
-		self:Start()
-		playerName = GameLib.GetPlayerUnit():GetName():gsub(NO_BREAK_SPACE, " ")
-		prev = 0
-		waveCount, beamCount = 0, 0
-		phase2 = false
-		core:AddBar("BEAM", self.L["NEXT BEAM"], 24)
-		core:AddBar("WAVE", self.L["[%u] WAVE"]:format(waveCount + 1), 24, mod:GetSetting("SoundNewWave"))
-		core:Berserk(600)
-	elseif sName == self.L["Data Devourer"] then
+	if sName == self.L["Data Devourer"] then
 		core:DropPixie(unit:GetId())
 	end
 end
@@ -193,6 +181,14 @@ function mod:OnUnitStateChanged(unit, bInCombat, sName)
 				waveCount = waveCount + 1
 				core:AddMsg("WAVE", self.L["[%u] WAVE"]:format(waveCount), 5, mod:GetSetting("SoundNewWave", "Alert"))
 			end
+		elseif sName == self.L["Avatus"] then
+			playerName = GameLib.GetPlayerUnit():GetName():gsub(NO_BREAK_SPACE, " ")
+			prev = 0
+			waveCount, beamCount = 0, 0
+			phase2 = false
+			--core:AddBar("BEAM", self.L["NEXT BEAM"], 24)
+			--core:AddBar("WAVE", self.L["[%u] WAVE"]:format(waveCount + 1), 24, mod:GetSetting("SoundNewWave"))
+			core:Berserk(576)
 		end
 	end
 end

--- a/Encounters/GA/ExperimentX89.lua
+++ b/Encounters/GA/ExperimentX89.lua
@@ -7,9 +7,7 @@ local core = Apollo.GetPackage("Gemini:Addon-1.1").tPackage:GetAddon("RaidCore")
 local mod = core:NewEncounter("ExperimentX89", 67, 147, 148)
 if not mod then return end
 
-mod:RegisterEnableMob("Experiment X-89")
-mod:RegisterRestrictZone("ExperimentX89", "Isolation Chamber")
-mod:RegisterEnableZone("ExperimentX89", "Isolation Chamber")
+mod:RegisterTrigMob("ANY", { "Experiment X-89" })
 mod:RegisterEnglishLocale({
 	-- Unit names.
 	["Experiment X-89"] = "Experiment X-89",
@@ -126,13 +124,11 @@ end
 function mod:OnUnitStateChanged(unit, bInCombat, sName)
 	if unit:GetType() == "NonPlayer" and bInCombat then
 		if sName == self.L["Experiment X-89"] then
-			self:Start()
 			local playerUnit = GameLib.GetPlayerUnit()
 			playerName = playerUnit:GetName()
 			core:AddUnit(unit)
 			core:UnitDebuff(playerUnit)
 			core:WatchUnit(unit)
-			core:StartScan()
 			core:AddBar("KNOCKBACK", self.L["KNOCKBACK"], 6)
 			core:AddBar("SHOCKWAVE", self.L["SHOCKWAVE"], 17)
 			core:AddBar("BEAM", self.L["BEAM"], 36)

--- a/Encounters/GA/Kuralak.lua
+++ b/Encounters/GA/Kuralak.lua
@@ -7,9 +7,7 @@ local core = Apollo.GetPackage("Gemini:Addon-1.1").tPackage:GetAddon("RaidCore")
 local mod = core:NewEncounter("Kuralak", 67, 147, 148)
 if not mod then return end
 
-mod:RegisterEnableMob("Kuralak the Defiler")
-mod:RegisterRestrictZone("Kuralak", "Archive Access Core")
-mod:RegisterEnableZone("Kuralak", "Archive Access Core")
+mod:RegisterTrigMob("ANY", { "Kuralak the Defiler" })
 mod:RegisterEnglishLocale({
 	-- Unit names.
 	["Kuralak the Defiler"] = "Kuralak the Defiler",
@@ -130,19 +128,11 @@ function mod:OnBossEnable()
 	Apollo.RegisterEventHandler("CHAT_DATACHRON", "OnChatDC", self)
 	Apollo.RegisterEventHandler("CHAT_NPCSAY", "OnChatNPCSay", self)
 	Apollo.RegisterEventHandler("DEBUFF_APPLIED", "OnDebuffApplied", self)
-	Apollo.RegisterEventHandler("RC_UnitCreated", "OnUnitCreated", self)
 end
 
 --------------------------------------------------------------------------------
 -- Event Handlers
 --
-
-function mod:OnUnitCreated(unit, sName)
-	if sName == self.L["Kuralak the Defiler"] then
-		core:AddUnit(unit)
-	end
-end
-
 function mod:OnHealthChanged(unitName, health)
 	if health == 74 and unitName == self.L["Kuralak the Defiler"] then
 		core:AddMsg("P2", self.L["P2 SOON !"], 5, "Info")
@@ -208,7 +198,6 @@ function mod:OnChatNPCSay(message)
 			local nordpos = { x = 175.00, y = -110.80034637451, z = -513.31 }
 			core:SetWorldMarker(nordpos, self.L["MARKER north"])
 			core:RaidDebuff()
-			core:StartScan()
 		end
 end
 
@@ -222,7 +211,6 @@ end
 function mod:OnUnitStateChanged(unit, bInCombat, sName)
 	if unit:GetType() == "NonPlayer" and bInCombat then
 		if sName == self.L["Kuralak the Defiler"] then
-			self:Start()
 			core:AddUnit(unit)
 			eggsCount, siphonCount, outbreakCount = 2, 1, 0
 		end

--- a/Encounters/GA/Ohmna.lua
+++ b/Encounters/GA/Ohmna.lua
@@ -7,9 +7,7 @@ local core = Apollo.GetPackage("Gemini:Addon-1.1").tPackage:GetAddon("RaidCore")
 local mod = core:NewEncounter("Ohmna", 67, 147, 149)
 if not mod then return end
 
-mod:RegisterEnableMob("Dreadphage Ohmna")
-mod:RegisterRestrictEventObjective("Ohmna", "Defeat Dreadphage Ohmna")
-mod:RegisterEnableEventObjective("Ohmna", "Defeat Dreadphage Ohmna")
+mod:RegisterTrigMob("ANY", { "Dreadphage Ohmna" })
 mod:RegisterEnglishLocale({
 	-- Unit names.
 	["Dreadphage Ohmna"] = "Dreadphage Ohmna",
@@ -174,8 +172,6 @@ function mod:OnUnitCreated(unit, sName)
 	elseif sName == self.L["Ravenous Maw of the Dreadphage"] then
 		core:MarkUnit(unit, 0)
 		core:AddLine(unit:GetId(), 2, unit, nil, 3, 25, 0)
-	elseif sName == self.L["Dreadphage Ohmna"] then
-		core:AddUnit(unit)
 	end
 end
 
@@ -251,7 +247,6 @@ function mod:OnChatDC(message)
 			pilarCount, boreCount = 1, 0
 			submergeCount = submergeCount + 1
 			core:StopBar("OTENT")
-			core:StartScan()
 		elseif message:find(self.L["Dreadphage Ohmna is bored"]) then
 			boreCount = boreCount + 1
 			if boreCount < 2 and self:Tank() then
@@ -265,14 +260,12 @@ function mod:OnChatDC(message)
 			core:StopBar("OPILAR")
 			core:StopBar("OBORE")
 			core:AddBar("OSPEW", self.L["NEXT BIG SPEW"], 45, 1)
-			core:StartScan()
 		end
 end
 
 function mod:OnUnitStateChanged(unit, bInCombat, sName)
 	if unit:GetType() == "NonPlayer" and bInCombat then
 		if sName == self.L["Dreadphage Ohmna"] then
-			self:Start()
 			pilarCount, boreCount, submergeCount = 1, 0, 0
 			firstPull, OhmnaP3, OhmnaP4 = true, false, false
 			core:AddUnit(unit)

--- a/Encounters/GA/PhageCouncil.lua
+++ b/Encounters/GA/PhageCouncil.lua
@@ -7,9 +7,9 @@ local core = Apollo.GetPackage("Gemini:Addon-1.1").tPackage:GetAddon("RaidCore")
 local mod = core:NewEncounter("PhageCouncil", 67, 147, 149)
 if not mod then return end
 
-mod:RegisterEnableMob("Golgox the Lifecrusher", "Terax Blightweaver", "Ersoth Curseform", "Noxmind the Insidious", "Fleshmonger Vratorg")
-mod:RegisterRestrictZone("PhageCouncil", "Augmentation Core")
-mod:RegisterEnableZone("PhageCouncil", "Augmentation Core")
+mod:RegisterTrigMob("ANY", {
+    "Golgox the Lifecrusher", "Terax Blightweaver", "Ersoth Curseform", "Noxmind the Insidious",
+    "Fleshmonger Vratorg"})
 mod:RegisterEnglishLocale({
 	-- Unit names.
 	["Terax Blightweaver"] = "Terax Blightweaver",
@@ -136,8 +136,6 @@ function mod:OnUnitStateChanged(unit, bInCombat, sName)
 			or sName == self.L["Ersoth Curseform"]
 			or sName == self.L["Noxmind the Insidious"]
 			or sName == self.L["Fleshmonger Vratorg"] then
-			self:Start()
-			core:StartScan()
 			p2Count = 0
 			core:AddBar("CONVP1", self.L["[%u] NEXT P2"]:format(p2Count + 1), 90, 1)
 			core:AddUnit(unit)

--- a/Encounters/GA/Phagemaw.lua
+++ b/Encounters/GA/Phagemaw.lua
@@ -7,9 +7,7 @@ local core = Apollo.GetPackage("Gemini:Addon-1.1").tPackage:GetAddon("RaidCore")
 local mod = core:NewEncounter("PhageMaw", 67, 147, 149)
 if not mod then return end
 
-mod:RegisterEnableMob("Phage Maw")
-mod:RegisterRestrictZone("PhageMaw", "Experimentation Lab CX-33")
-mod:RegisterEnableZone("PhageMaw", "Experimentation Lab CX-33")
+mod:RegisterTrigMob("ANY", { "Phage Maw" })
 mod:RegisterEnglishLocale({
 	-- Unit names.
 	["Phage Maw"] = "Phage Maw",
@@ -84,7 +82,6 @@ end
 function mod:OnUnitStateChanged(unit, bInCombat, sName)
 	if unit:GetType() == "NonPlayer" and bInCombat then
 		if sName == self.L["Phage Maw"] then
-			self:Start()
 			core:AddUnit(unit)
 		end
 	end

--- a/Encounters/GA/Prototypes.lua
+++ b/Encounters/GA/Prototypes.lua
@@ -7,9 +7,8 @@ local core = Apollo.GetPackage("Gemini:Addon-1.1").tPackage:GetAddon("RaidCore")
 local mod = core:NewEncounter("Prototypes", 67, 147, 149)
 if not mod then return end
 
-mod:RegisterEnableMob("Phagetech Commander", "Phagetech Augmentor", "Phagetech Protector", "Phagetech Fabricator")
-mod:RegisterRestrictZone("Prototypes", "Phagetech Uplink Hub")
-mod:RegisterEnableZone("Prototypes", "Phagetech Uplink Hub")
+mod:RegisterTrigMob("ANY", {
+    "Phagetech Commander", "Phagetech Augmentor", "Phagetech Protector", "Phagetech Fabricator"})
 mod:RegisterEnglishLocale({
 	-- Unit names.
 	["Phagetech Commander"] = "Phagetech Commander",
@@ -134,10 +133,8 @@ end
 function mod:OnUnitStateChanged(unit, bInCombat, sName)
 	if unit:GetType() == "NonPlayer" and bInCombat then
 		if sName == self.L["Phagetech Commander"] then
-			self:Start()
 		elseif sName == self.L["Phagetech Augmentor"] or sName == self.L["Phagetech Fabricator"] then
 			core:WatchUnit(unit)
-			core:StartScan()
 		end
 	end
 end

--- a/Encounters/TEST/GalerasTest.lua
+++ b/Encounters/TEST/GalerasTest.lua
@@ -16,50 +16,51 @@ local mod = core:NewEncounter("GalerasTest", 6, 0, 16)
 --@end-alpha@
 if not mod then return end
 
-mod:RegisterEnableMob("Crimson Spiderbot")
+mod:RegisterTrigMob("ANY", { "Crimson Spiderbot", "Crimson Clanker" })
 mod:RegisterEnglishLocale({
-	-- Unit names.
-	["Crimson Spiderbot"] = "Crimson Spiderbot",
-	["Phaser Combo"] = "Phaser Combo",
+    -- Unit names.
+    ["Crimson Clanker"] = "Crimson Clanker",
+    ["Crimson Spiderbot"] = "Crimson Spiderbot",
+    ["Phaser Combo"] = "Phaser Combo",
 })
 mod:RegisterFrenchLocale({
-	-- Unit names.
-	["Crimson Spiderbot"] = "Arachnobot écarlate",
-	["Phaser Combo"] = "Combo de phaser",
+    -- Unit names.
+    ["Crimson Clanker"] = "Cybernéticien écarlate",
+    ["Crimson Spiderbot"] = "Arachnobot écarlate",
+    ["Phaser Combo"] = "Combo de phaser",
 })
 
 function mod:OnBossEnable()
-	Apollo.RegisterEventHandler("RC_UnitCreated", "OnUnitCreated", self)
-	Apollo.RegisterEventHandler("RC_UnitStateChanged", "OnUnitStateChanged", self)
-	Apollo.RegisterEventHandler("SPELL_CAST_START", "OnSpellCastStart", self)
-	Apollo.RegisterEventHandler("SPELL_CAST_END", "OnSpellCastEnd", self)
+    Apollo.RegisterEventHandler("RC_UnitCreated", "OnUnitCreated", self)
+    Apollo.RegisterEventHandler("RC_UnitStateChanged", "OnUnitStateChanged", self)
+    Apollo.RegisterEventHandler("SPELL_CAST_START", "OnSpellCastStart", self)
+    Apollo.RegisterEventHandler("SPELL_CAST_END", "OnSpellCastEnd", self)
 end
 
 function mod:OnUnitCreated(unit, sName)
-	if sName == self.L["Crimson Spiderbot"] then
-		core:AddUnit(unit)
-	end
+    if sName == self.L["Crimson Spiderbot"] then
+        core:MarkUnit(unit, 1, "A")
+    end
 end
 
 function mod:OnUnitStateChanged(unit, bInCombat, sName)
-	if bInCombat then
-		if unit == GameLib.GetPlayerUnit() then
-			self:Start()
-		elseif sName == self.L["Crimson Spiderbot"] then
-			core:WatchUnit(unit)
-			core:MarkUnit(unit, 1, "X")
-		end
-	end
+    if bInCombat then
+        if sName == self.L["Crimson Spiderbot"] then
+            core:WatchUnit(unit)
+            core:AddUnit(unit)
+            core:MarkUnit(unit, 1, "X")
+        end
+    end
 end
 
 function mod:OnSpellCastStart(unitName, castName, unit)
-	if castName == self.L["Phaser Combo"] then
-		Print("Cast Start")
-	end
+    if castName == self.L["Phaser Combo"] then
+        Print("Cast Start")
+    end
 end
 
 function mod:OnSpellCastEnd(unitName, castName, unit)
-	if castName == self.L["Phaser Combo"] then
-		Print("Cast End")
-	end
+    if castName == self.L["Phaser Combo"] then
+        Print("Cast End")
+    end
 end

--- a/Locales/deDE.lua
+++ b/Locales/deDE.lua
@@ -8,18 +8,3 @@ local GeminiLocale = Apollo.GetPackage("Gemini:Locale-1.0").tPackage
 local L = GeminiLocale:NewLocale("RaidCore", "deDE", false, true)
 if not L then return end
 
--- Zone translation. Temporary translation.
-L["Elemental Vortex Alpha"] = "Elementarvortex Alpha"
-L["Elemental Vortex Beta"] = "Elementarvortex Beta"
-L["Elemental Vortex Delta"] = "Elementarvortex Delta"
---L["Phagetech Uplink Hub"] = "Phagetech Uplink Hub" -- 	-- TODO: German translation missing !!!!
---L["Isolation Chamber"] = "Isolation Chamber" -- 	-- TODO: German translation missing !!!!
---L["Archive Access Core"] = "Archive Access Core" -- 	-- TODO: German translation missing !!!!
---L["Augmentation Core"] = "Augmentation Core" -- 	-- TODO: German translation missing !!!!
---L["Experimentation Lab CX-33"] = "Experimentation Lab CX-33" -- 	-- TODO: German translation missing !!!!
-L["Halls of the Infinite Mind"] = "Hallen des Unendlichen Geistes"
---L["Infinite Generator Core"] = "Infinite Generator Core" -- 	-- TODO: German translation missing !!!!
-L["Lower Infinite Generator Core"] = "Unterer unendlicher Generatorkern"
---L["Defeat the System Daemons"] = "Defeat the System Daemons" -- 	-- TODO: German translation missing !!!!
-L["The Oculus"] = "Der Oculus"
---L["Defeat Dreadphage Ohmna"] = "Defeat Dreadphage Ohmna" -- 	-- TODO: German translation missing !!!!

--- a/Locales/enUS.lua
+++ b/Locales/enUS.lua
@@ -8,18 +8,3 @@ local GeminiLocale = Apollo.GetPackage("Gemini:Locale-1.0").tPackage
 local L = GeminiLocale:NewLocale("RaidCore", "enUS", true, true)
 if not L then return end
 
--- Zone translation. Temporary translation.
-L["Elemental Vortex Alpha"] = "Elemental Vortex Alpha"
-L["Elemental Vortex Beta"] = "Elemental Vortex Beta"
-L["Elemental Vortex Delta"] = "Elemental Vortex Delta"
-L["Phagetech Uplink Hub"] = "Phagetech Uplink Hub"
-L["Isolation Chamber"] = "Isolation Chamber"
-L["Archive Access Core"] = "Archive Access Core"
-L["Augmentation Core"] = "Augmentation Core"
-L["Experimentation Lab CX-33"] = "Experimentation Lab CX-33"
-L["Halls of the Infinite Mind"] = "Halls of the Infinite Mind"
-L["Infinite Generator Core"] = "Infinite Generator Core"
-L["Lower Infinite Generator Core"] = "Lower Infinite Generator Core"
-L["Defeat the System Daemons"] = "Defeat the System Daemons"
-L["The Oculus"] = "The Oculus"
-L["Defeat Dreadphage Ohmna"] = "Defeat Dreadphage Ohmna"

--- a/Locales/frFR.lua
+++ b/Locales/frFR.lua
@@ -8,18 +8,3 @@ local GeminiLocale = Apollo.GetPackage("Gemini:Locale-1.0").tPackage
 local L = GeminiLocale:NewLocale("RaidCore", "frFR", false, true)
 if not L then return end
 
--- Zone translation. Temporary translation.
-L["Elemental Vortex Alpha"] = "Vortex élementaire Alpha"
-L["Elemental Vortex Beta"] = "Vortex élementaire Bêta"
-L["Elemental Vortex Delta"] = "Vortex élementaire Delta"
---L["Phagetech Uplink Hub"] = "Phagetech Uplink Hub" -- 	-- TODO: French translation missing !!!!
---L["Isolation Chamber"] = "Isolation Chamber" -- 	-- TODO: French translation missing !!!!
---L["Archive Access Core"] = "Archive Access Core" -- 	-- TODO: French translation missing !!!!
---L["Augmentation Core"] = "Augmentation Core" -- 	-- TODO: French translation missing !!!!
---L["Experimentation Lab CX-33"] = "Experimentation Lab CX-33" -- 	-- TODO: French translation missing !!!!
-L["Halls of the Infinite Mind"] = "Salles de l'Esprit infini"
-L["Infinite Generator Core"] = "Noyau du générateur d'infinité"
-L["Lower Infinite Generator Core"] = "Noyau du générateur d'infinité inférieur"
---L["Defeat the System Daemons"] = "Defeat the System Daemons" -- 	-- TODO: French translation missing !!!!
-L["The Oculus"] = "Oculus"
-L["Defeat Dreadphage Ohmna"] = "Terrasser Ohmna la Terriphage"

--- a/RaidCore.lua
+++ b/RaidCore.lua
@@ -14,12 +14,15 @@ require "ChatSystemLib"
 local GeminiAddon = Apollo.GetPackage("Gemini:Addon-1.1").tPackage
 local LogPackage = Apollo.GetPackage("Log-1.0").tPackage
 local RaidCore = GeminiAddon:NewAddon("RaidCore", false, {}, "Gemini:Timer-1.0")
+local Log = LogPackage:CreateNamespace("CombatManager")
 
 ----------------------------------------------------------------------------------------------------
 -- Copy of few objects to reduce the cpu load.
 -- Because all local objects are faster.
 ----------------------------------------------------------------------------------------------------
 local GetPlayerUnit = GameLib.GetPlayerUnit
+local GetUnitById = GameLib.GetUnitById
+local GetCurrentZoneMap = GameLib.GetCurrentZoneMap
 
 ----------------------------------------------------------------------------------------------------
 -- Constants.
@@ -32,9 +35,13 @@ local NO_BREAK_SPACE = string.char(194, 160)
 -- Privates variables.
 ----------------------------------------------------------------------------------------------------
 local _wndrclog = nil
-local enablezones, enablemobs, enablepairs, restrictzone, enablezone, restricteventobjective, enableeventobjective = {}, {}, {}, {}, {}, {}, {}
-local monitoring = nil
 local _tWipeTimer
+local _tHUDtimer
+local _tTrigPerZone = {}
+local _tEncountersPerZone = {}
+local _tDelayedUnits = {}
+local _bIsEncounterInProgress = false
+local _tCurrentEncounter = nil
 
 
 local trackMaster = Apollo.GetAddon("TrackMaster")
@@ -224,6 +231,68 @@ local DefaultSettings = {
 }
 
 ----------------------------------------------------------------------------------------------------
+-- Privates functions
+----------------------------------------------------------------------------------------------------
+local function ManageDelayedUnit(nId, sName, bInCombat)
+    local tMap = GetCurrentZoneMap()
+    local id1 = tMap.continentId
+    local id2 = tMap.parentZoneId
+    local id3 = tMap.id
+    local tTrig = _tTrigPerZone[id1] and _tTrigPerZone[id1][id2] and _tTrigPerZone[id1][id2][id3]
+    if tTrig and tTrig[sName] then
+        if bInCombat then
+            Log:Add("Add2DelayedUnit", nId, sName)
+            if not _tDelayedUnits[sName] then
+                _tDelayedUnits[sName] = {}
+            end
+            _tDelayedUnits[sName][nId] = true
+        else
+            if _tDelayedUnits[sName] then
+                if _tDelayedUnits[sName][nId] then
+                    Log:Add("Remove2DelayedUnit", nId, sName)
+                    _tDandelayedUnits[sName][nId] = nil
+                end
+                if next(_tDelayedUnits[sName]) == nil then
+                    _tDelayedUnits[sName] = nil
+                end
+            end
+        end
+    end
+end
+
+local function SearchEncounter()
+    local tMap = GetCurrentZoneMap()
+    local id1 = tMap.continentId
+    local id2 = tMap.parentZoneId
+    local id3 = tMap.id
+    local tEncounters = _tEncountersPerZone[id1] and _tEncountersPerZone[id1][id2] and _tEncountersPerZone[id1][id2][id3]
+    if tEncounters then
+        for _, tEncounter in next, tEncounters do
+            if tEncounter:OnTrig(_tDelayedUnits) then
+                _tCurrentEncounter = tEncounter
+                Log:Add("Encounter Found", _tCurrentEncounter:GetName())
+                break
+            end
+        end
+    end
+end
+
+local function ProcessDelayedUnit()
+    for nDelayedName, tDelayedList in next, _tDelayedUnits do
+        for nDelayedId, _ in next, tDelayedList do
+            local tUnit = GetUnitById(nDelayedId)
+            if tUnit then
+                local bInCombat = tUnit:IsInCombat()
+                Event_FireGenericEvent("RC_UnitStateChanged", tUnit, bInCombat, nDelayedName)
+            else
+                Log:Add("Error Invalid tUnit not found", nDelayedName, nDelayedId)
+            end
+        end
+    end
+    _tDelayedUnits = {}
+end
+
+----------------------------------------------------------------------------------------------------
 -- RaidCore Initialization
 ----------------------------------------------------------------------------------------------------
 function RaidCore:OnInitialize()
@@ -300,9 +369,8 @@ function RaidCore:OnDocLoaded()
 	-- Register handlers for events, slash commands and timer, etc.
 	Apollo.RegisterSlashCommand("raidc", "OnRaidCoreOn", self)
 	Apollo.RegisterEventHandler("Group_MemberFlagsChanged", "OnGroup_MemberFlagsChanged", self)
-	Apollo.RegisterEventHandler("ChangeWorld", "OnWorldChangedTimer", self)
-	Apollo.RegisterEventHandler("SubZoneChanged", "OnSubZoneChanged", self)
-	Apollo.RegisterEventHandler("PublicEventObjectiveUpdate", "OnPublicEventObjectiveUpdate", self)
+    Apollo.RegisterEventHandler("ChangeWorld", "OnCheckMapZone", self)
+    Apollo.RegisterEventHandler("SubZoneChanged", "OnCheckMapZone", self)
 
 	-- Do additional Addon initialization here
 
@@ -320,25 +388,48 @@ function RaidCore:OnDocLoaded()
 
     _tWipeTimer = ApolloTimer.Create(0.5, true, "WipeCheck", self)
     _tWipeTimer:Stop()
+    _tHUDtimer = ApolloTimer.Create(0.1, true, "OnTimer", self)
+    _tHUDtimer:Stop()
 
 	self.lines = {}
 
 	self.chanCom = nil
 	CommChannelTimer = ApolloTimer.Create(5, false, "UpdateCommChannel", self) -- make sure everything is loaded, so after 5sec
 
-	-- Final parsing about encounters.
-	for name, module in self:IterateModules() do
-		local r, e = pcall(module.PrepareEncounter, module)
-		if not r then
-			Print(e)
-		else
-			for _, id in next, module.continentIdList do
-				enablezones[id] = true
-			end
-		end
-	end
-	self:ScheduleTimer("OnWorldChanged", 5)
-	self:LogGUI_init()
+    -- Final parsing about encounters.
+    for name, module in self:IterateModules() do
+        local r, e = pcall(module.PrepareEncounter, module)
+        if not r then
+            Print(e)
+        else
+            for _, id1 in next, module.continentIdList do
+                if _tTrigPerZone[id1] == nil then
+                    _tTrigPerZone[id1] = {}
+                    _tEncountersPerZone[id1] = {}
+                end
+                for _, id2 in next, module.parentMapIdList do
+                    if _tTrigPerZone[id1][id2] == nil then
+                        _tTrigPerZone[id1][id2] = {}
+                        _tEncountersPerZone[id1][id2] = {}
+                    end
+                    for _, id3 in next, module.mapIdList do
+                        if _tTrigPerZone[id1][id2][id3] == nil then
+                            _tTrigPerZone[id1][id2][id3] = {}
+                            _tEncountersPerZone[id1][id2][id3] = {}
+                        end
+                        table.insert(_tEncountersPerZone[id1][id2][id3], module)
+                        if module.EnableMob then
+                            for _, Mob in next, module.EnableMob do
+                                _tTrigPerZone[id1][id2][id3][Mob] = true
+                            end
+                        end
+                    end
+                end
+            end
+        end
+    end
+    self:LogGUI_init()
+    self:OnCheckMapZone()
 end
 
 ----------------------------------------------------------------------------------------------------
@@ -731,213 +822,31 @@ function RaidCore:hasActiveEvent(tblEvents)
 	return false
 end
 
-function RaidCore:OnUnitCreated(nId, unit, sName)
-	Event_FireGenericEvent("RC_UnitCreated", unit, sName)
-	if unit and not unit:IsDead() then
-		if sName and enablemobs[sName] then
-			if type(enablemobs[sName]) == "string" then
-				local modName = enablemobs[sName]
-				local module = self:GetModule(modName)
-				if not module or module:IsEnabled() then return end
-				if restrictzone[modName] and not restrictzone[modName][GetCurrentSubZoneName()] then return end
-				if restricteventobjective[modName] and not self:hasActiveEvent(restricteventobjective[modName]) then return end
-				Print("Enabling Boss Module : " .. enablemobs[sName])
-				for name, mod in self:IterateModules() do
-					if mod:IsEnabled() then mod:Disable() end
-				end
-				module:Enable()
-			else
-				for i, modName in next, enablemobs[sName] do
-					local module = self:GetModule(modName)
-					if not module or module:IsEnabled() then return end
-				end
-				for name, mod in self:IterateModules() do
-					if mod:IsEnabled() then mod:Disable() end
-				end
-				for i, modName in next, enablemobs[sName] do
-					local module = self:GetModule(modName)
-					if restrictzone[modName] and not restrictzone[modName][GetCurrentSubZoneName()] then return end
-					if restricteventobjective[modName] and not self:hasActiveEvent(restricteventobjective[modName]) then return end
-					Print("Enabling Boss Module : " .. modName)
-					module:Enable()
-				end
-			end
-		else
-			-- Check if part of a boss combination pair
-			for modName, bosses in pairs(enablepairs) do
-				for bossName, activeState in pairs(bosses) do
-					if sName == bossName then
-						-- Set this boss to true if it is active
-						enablepairs[modName][bossName] = true
-					end
-				end
-			end
-			-- Loop again to check if there's any boss pair that has
-			-- all bosses that are required for it to activate active
-			for modName, bosses in pairs(enablepairs) do
-				local bModNameBossActive = true
-				for bossName, activeState in pairs(bosses) do
-					if bModNameBossActive and not activeState then
-						bModNameBossActive = false
-					end
-				end
-
-				-- At this point we know this boss pair should be enabled.
-				if bModNameBossActive then
-					-- Disable any other modules that are active
-					for name, mod in self:IterateModules() do
-						if name ~= modName and mod:IsEnabled() then
-							mod:Disable()
-						end
-					end
-					mod = self:GetModule(modName)
-					if restrictzone[modName] and not restrictzone[modName][GetCurrentSubZoneName()] then return end
-					if mod:IsEnabled() then return end
-					Print("Enabling Boss Module : " .. modName)
-					mod:Enable()
-					return
-				end
-			end
-		end
-	end
-end
-
-
-function RaidCore:StartCombat(modName)
-	Print("Starting Core Combat")
-	for name, mod in self:IterateModules() do
-		if mod:IsEnabled() and mod.ModuleName ~= modName then
-			mod:Disable()
-		end
-	end
-end
-
-function RaidCore:OnWorldChangedTimer()
-	self:ScheduleTimer("OnWorldChanged", 5)
-end
-
-
-function RaidCore:OnWorldChanged()
-	local zoneMap = GameLib.GetCurrentZoneMap()
-
-	if zoneMap then
-		if enablezones[zoneMap.continentId] then
-			self:CombatInterface_Activate("DetectAll")
-			monitoring = true
-			if self.timer == nil then
-				self.timer = ApolloTimer.Create(0.100, true, "OnTimer", self)
-			else
-				self.timer:Start()
-			end
-		else
-			self:CombatInterface_Activate("Disable")
-			if monitoring then
-				monitoring = nil
-				self:ResetAll()
-				self.timer:Stop()
-			end
-		end
-	else
-		self:ScheduleTimer("OnWorldChanged", 5)
-	end
-end
-
-function RaidCore:OnSubZoneChanged(idZone, strSubZone)
-	for key, value in pairs(enablezone) do
-		if value[strSubZone] then
-			local modName = key
-			local bossMod = self:GetModule(modName)
-			if not bossMod or bossMod:IsEnabled() then return end
-			if restricteventobjective[modName] and not self:hasActiveEvent(restricteventobjective[modName]) then return end
-			Print("Enabling Boss Module : " .. modName)
-			bossMod:Enable()
-			return
-		end
-	end
-	-- if we haven't returned at this point we left the subzone and should disable the mod
-	-- if it is still enabled
-	for name, mod in self:IterateModules() do
-		for key, value in pairs(enablezone) do
-			local modName = mod.ModuleName
-			if key == modName and mod:IsEnabled() then
-				mod:Disable()
-			end
-		end
-	end
-end
-
-function RaidCore:OnPublicEventObjectiveUpdate(peoUpdated)
-	for key, value in pairs(enableeventobjective) do
-		if value[peoUpdated:GetShortDescription()] then
-			if peoUpdated:GetStatus() == 1 then
-				local modName = key
-				local bossMod = self:GetModule(modName)
-				if not bossMod or bossMod:IsEnabled() then return end
-				if restrictzone[modName] and not restrictzone[modName][GetCurrentSubZoneName()] then return end
-				Print("Enabling Boss Module : " .. modName)
-				bossMod:Enable()
-				return
-			elseif peoUpdated:GetStatus() == 0 then
-				local modName = key
-				local bossMod = self:GetModule(modName)
-				if not bossMod or not bossMod:IsEnabled() then return end
-				bossMod:Disable()
-			end
-		end
-	end
-end
-
-do
-	local function add(moduleName, tbl, list)
-		for i, entry in next, list do
-			local t = type(tbl[entry])
-			if t == "nil" then
-				tbl[entry] = moduleName
-			elseif t == "table" then
-				tbl[entry][#tbl[entry] + 1] = moduleName
-			elseif t == "string" then
-				local tmp = tbl[entry]
-				tbl[entry] = { tmp, moduleName }
-			else
-				Print(("Unknown type in a enable trigger table at index %d for %q."):format(i, tostring(moduleName)))
-			end
-		end
-	end
-
-	local function addPair(moduleName, tbl, list)
-		-- ... is holding our actual bosses that we want to have in a pair
-		-- we will store them in the tbl (enablepairs)
-		local bosses = {}
-		for key, value in next, list do
-			-- Defaults to false meaning the unit is not active/in-range
-			bosses[value] = false
-		end
-		tbl[moduleName] = bosses
-	end
-
-	function RaidCore:RegisterEnableMob(module, list) add(module.ModuleName, enablemobs, list) end
-	function RaidCore:RegisterEnableBossPair(module, list) addPair(module.ModuleName, enablepairs, list) end
-	function RaidCore:GetEnableMobs() return enablemobs end
-	function RaidCore:GetEnablePairs() return enablepairs end
-	function RaidCore:GetRestrictZone() return restrictzone end
-	function RaidCore:GetRestrictEventObjective() return restricteventobjective end
-	function RaidCore:GetEnableEventObjective() return enableeventobjective end
-	function RaidCore:GetEnableZone() return enablezone end
-end
-
-
-do
-	local function add2(moduleName, tbl, list)
-		if not tbl[moduleName] then tbl[moduleName] = {} end
-		for i, entry in next, list do
-			if not tbl[moduleName][entry] then tbl[moduleName][entry] = true end
-		end
-	end
-
-	function RaidCore:RegisterRestrictZone(module, list) add2(module.ModuleName, restrictzone, list) end
-	function RaidCore:RegisterEnableZone(module, list) add2(module.ModuleName, enablezone, list) end
-	function RaidCore:RegisterRestrictEventObjective(module, list) add2(module.ModuleName, restricteventobjective, list) end
-	function RaidCore:RegisterEnableEventObjective(module, list) add2(module.ModuleName, enableeventobjective, list) end
+function RaidCore:OnCheckMapZone()
+    if not _bIsEncounterInProgress then
+        local tMap = GetCurrentZoneMap()
+        if tMap then
+            local tTrigInZone = _tTrigPerZone[tMap.continentId]
+            local bSearching = false
+            if tTrigInZone then
+                tTrigInZone = tTrigInZone[tMap.parentZoneId]
+                if tTrigInZone then
+                    tTrigInZone = tTrigInZone[tMap.id]
+                    if tTrigInZone then
+                        bSearching = true
+                    end
+                end
+            end
+            if bSearching then
+                self:CombatInterface_Activate("DetectCombat")
+            else
+                self:CombatInterface_Activate("Disable")
+                self:ResetAll()
+            end
+        else
+            self:ScheduleTimer("OnCheckMapZone", 5)
+        end
+    end
 end
 
 function RaidCore:AddBar(key, message, duration, emphasize)
@@ -1150,31 +1059,6 @@ function RaidCore:OnUnitDestroyed(key, unit, unitName)
 	end
 	if self.buffs[key] then
 		self.buffs[key] = nil
-	end
-
-	-- Unload boss module if all units are destroyed within a module
-	for modName, bosses in pairs(enablepairs) do
-		for bossName, activeState in pairs(bosses) do
-			if activeState and bossName == unitName then
-				enablepairs[modName][bossName] = false
-			end
-		end
-	end
-	for modName, bosses in pairs(enablepairs) do
-		local bModNameBossActive = false
-		for bossName, activeState in pairs(bosses) do
-			if not bModNameBossActive and activeState then
-				bModNameBossActive = true
-			end
-		end
-		if not bModNameBossActive then
-			-- Disable any other modules that are active
-			for name, mod in self:IterateModules() do
-				if name == modName and mod:IsEnabled() then
-					mod:Disable()
-				end
-			end
-		end
 	end
 end
 
@@ -1407,6 +1291,12 @@ function RaidCore:WipeCheck()
 		self:CancelTimer(self.berserk)
 		self.berserk = nil
 	end
+    Log:Add("Encounter no more in progress")
+    _bIsEncounterInProgress = false
+    if _tCurrentEncounter then
+        _tCurrentEncounter:Disable()
+        _tCurrentEncounter = nil
+    end
 	self.raidbars:ClearAll()
 	self.unitmoni:ClearAll()
 	self.message:ClearAll()
@@ -1420,26 +1310,47 @@ function RaidCore:WipeCheck()
 	self:ResetSync()
 	self:ResetLines()
 
-	-- XXX Zone not Checked!
-	self:CombatInterface_Activate("DetectAll")
+    _tHUDtimer:Stop()
+    self:CombatInterface_Activate("DetectCombat")
 	Event_FireGenericEvent("RAID_WIPE")
 end
 
-function RaidCore:OnEnteredCombat(id, unit, UnitName, bInCombat)
-	Event_FireGenericEvent("RC_UnitStateChanged", unit, bInCombat, UnitName)
+function RaidCore:OnUnitCreated(nId, tUnit, sName)
+    Event_FireGenericEvent("RC_UnitCreated", tUnit, sName)
+end
 
-	if unit == GetPlayerUnit() then
-		if bInCombat then
-			-- Player entering in combat.
-			self:CombatInterface_Activate("FullEnable")
-		else
-			-- Player is dead or left the combat.
-			_tWipeTimer:Start()
-		end
-	elseif unit:IsInYourGroup() then
-		-- It's a raid member or group member.
-	else
-	end
+function RaidCore:OnEnteredCombat(nId, tUnit, sName, bInCombat)
+    -- Manage the lower layer.
+    if tUnit == GetPlayerUnit() then
+        if bInCombat then
+            -- Player entering in combat.
+            Log:Add("Player In Combat")
+            _bIsEncounterInProgress = true
+            self:CombatInterface_Activate("FullEnable")
+            _tHUDtimer:Start()
+            if _tCurrentEncounter and not _tCurrentEncounter:IsEnabled() then
+                _tCurrentEncounter:Enable()
+                ProcessDelayedUnit()
+            end
+        else
+            -- Player is dead or left the combat.
+            _tWipeTimer:Start()
+        end
+    elseif not tUnit:IsInYourGroup() then
+        if not _tCurrentEncounter then
+            ManageDelayedUnit(nId, sName, bInCombat)
+            if _bIsEncounterInProgress then
+                SearchEncounter()
+                if _tCurrentEncounter and not _tCurrentEncounter:IsEnabled() then
+                    _tCurrentEncounter:Enable()
+                    ProcessDelayedUnit()
+                end
+            end
+        else
+            -- Dispatch this Event to the Encounter
+            Event_FireGenericEvent("RC_UnitStateChanged", tUnit, bInCombat, sName)
+        end
+    end
 end
 
 local function IsPartyMemberByName(sName)


### PR DESCRIPTION
Now, an encounter start with EnteredCombat event, no more with UnitCreated.
All filters which were implemented to workaround the UnitCreated event have been erased.
