### PR TITLE
Update version for Drop 5

### DIFF
--- a/RaidCore.lua
+++ b/RaidCore.lua
@@ -49,7 +49,7 @@ local _tCurrentEncounter = nil
 
 local trackMaster = Apollo.GetAddon("TrackMaster")
 local markCount = 0
-local AddonVersion = 15031701
+local AddonVersion = 15050501
 local VCReply, VCtimer = {}, nil
 local CommChannelTimer = nil
 local empCD, empTimer = 5, nil

--- a/toc.xml
+++ b/toc.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Addon Author="Ninjouz" APIVersion="9" Name="RaidCore" Description="Core Functions for Raid Warnings" Version="0.2.0">
+<Addon Author="Ninjouz" APIVersion="10" Name="RaidCore" Description="Core Functions for Raid Warnings" Version="1.0">
 	<!-- Libraries -->
 	<Script Name="Libs/GeminiLocale/GeminiLocale.lua"/>
 	<Script Name="Libs/GeminiAddon/GeminiAddon.lua" />


### PR DESCRIPTION
Updates the API version and version-strings for the drop 5 release. After this ready to tag I think for Curse?
