### PR TITLE
Fix an issue that prevented OnReset() from working

### DIFF
--- a/RaidCore.lua
+++ b/RaidCore.lua
@@ -1334,6 +1334,7 @@ function RaidCore:WipeCheck()
     Log:Add("Encounter no more in progress")
     _bIsEncounterInProgress = false
     if _tCurrentEncounter then
+        Event_FireGenericEvent("RAID_WIPE")
         _tCurrentEncounter:Disable()
         _tCurrentEncounter = nil
     end
@@ -1352,7 +1353,6 @@ function RaidCore:WipeCheck()
 
     _tHUDtimer:Stop()
     self:CombatInterface_Activate("DetectCombat")
-    Event_FireGenericEvent("RAID_WIPE")
 end
 
 function RaidCore:OnUnitCreated(nId, tUnit, sName)


### PR DESCRIPTION
The RAID_WIPE event was fired after the encounter was disabled, at that
point it doesn't work so OnReset() was never called. Since this is
required for some fights, I moved the event handler so it fires before
disabling the module.

This was an issue specifically on Avatus, where it only worked the first
pull, until another reloadui happened.
