### PR TITLE
Add option to decline summons

### DIFF
--- a/RaidCore.lua
+++ b/RaidCore.lua
@@ -83,6 +83,7 @@ local DefaultSettings = {
             barColor = "ff00007f",
         },
         bSoundEnabled = true,
+        bAcceptSummons = true,
     },
     -- Datascape Settings
 
@@ -1432,7 +1433,7 @@ function RaidCore:OnComMessage(channel, strMessage, strSender)
             Event_FireGenericEvent("RAID_SYNC", tMessage.sync, tMessage.parameter)
         end
     elseif tMessage.action == "SyncSummon" then
-        if not self:isRaidManagement(strSender) then
+        if not self.settings["General"]["bAcceptSummons"] or not self:isRaidManagement(strSender) then
             return false
         end
         Print(tMessage.sender .. " requested that you accept a summon. Attempting to accept now.")

--- a/RaidCore.xml
+++ b/RaidCore.xml
@@ -211,6 +211,11 @@
                 <Event Name="ButtonUncheck" Function="OnGeneralCheckBoxUnchecked"/>
                 <Event Name="WindowLoad" Function="OnWindowLoadGeneral"/>
             </Control>
+            <Control Class="Button" Base="HologramSprites:HoloCheckBoxBtn" Font="DefaultButton" ButtonType="Check" RadioGroup="" LAnchorPoint="0" LAnchorOffset="10" TAnchorPoint="0" TAnchorOffset="330" RAnchorPoint="0" RAnchorOffset="416" BAnchorPoint="0" BAnchorOffset="356" DT_VCENTER="1" DT_CENTER="0" BGColor="UI_BtnBGDefault" TextColor="UI_BtnTextDefault" NormalTextColor="UI_BtnTextDefault" PressedTextColor="UI_BtnTextDefault" FlybyTextColor="UI_BtnTextDefault" PressedFlybyTextColor="UI_BtnTextDefault" DisabledTextColor="UI_BtnTextDefault" TooltipType="OnCursor" Name="Button_bAcceptSummons" TooltipColor="" Text="      Accept summon requests from raid leaders and assistants" TextId="" DT_SINGLELINE="1" Tooltip="" TooltipId="">
+                <Event Name="ButtonCheck" Function="OnGeneralCheckBoxChecked"/>
+                <Event Name="ButtonUncheck" Function="OnGeneralCheckBoxUnchecked"/>
+                <Event Name="WindowLoad" Function="OnWindowLoadGeneral"/>
+            </Control>
         </Control>
     </Form>
     <Form Class="Window" LAnchorPoint="0" LAnchorOffset="4" TAnchorPoint="0" TAnchorOffset="3" RAnchorPoint="1" RAnchorOffset="-21" BAnchorPoint="0" BAnchorOffset="441" RelativeToClient="0" Font="Default" Text="" BGColor="UI_WindowBGDefault" TextColor="UI_WindowTextDefault" Template="Holo_Scrolllist_Options" TooltipType="OnCursor" Name="ConfigForm_Gloomclaw" Border="0" Picture="0" SwallowMouseClicks="1" Moveable="0" Escapable="0" Overlapped="0" TooltipColor="" TextId="" Visible="0" Tooltip="" NotRelative="1">


### PR DESCRIPTION
Raid leaders and assistants can force people to accept pending summons
via /raidc summon.
This will allow people to override that option in the settings, so
summons are no longer automatically accepted.
