### PR TITLE
Fix world marker displayed on units not on screen, closes #90

### DIFF
--- a/RaidCore.lua
+++ b/RaidCore.lua
@@ -1004,7 +1004,7 @@ function RaidCore:MarkUnit(unit, location, mark)
             local markFrame = Apollo.LoadForm(self.xmlDoc, "MarkFrame", "InWorldHudStratum", self)
             markFrame:SetUnit(unit, location)
             markFrame:FindChild("Name"):SetText(self.mark[key].number)
-            markFrame:Show(true)
+            self:MarkerVisibilityHandler(markFrame)
 
             self.mark[key].frame = markFrame
         elseif mark then
@@ -1015,16 +1015,15 @@ function RaidCore:MarkUnit(unit, location, mark)
     end
 end
 
-function RaidCore:WorldMarkerVisibilityHandler(key)
-    -- If worldmarker was never on screen it might already have been destroyed again
+function RaidCore:MarkerVisibilityHandler(markFrame)
+    -- If marker was never on screen it might already have been destroyed again
     -- so we'll check if it still exists
-    local markFrame = self.worldmarker[key]
-    if not markFrame then return end
+    if not markFrame or not markFrame:IsValid() then return end
     if markFrame:IsOnScreen() then
         markFrame:Show(true)
     else
         -- run check again later
-        self:ScheduleTimer("WorldMarkerVisibilityHandler", 1, key)
+        self:ScheduleTimer("MarkerVisibilityHandler", 1, markFrame)
     end
 end
 
@@ -1041,7 +1040,7 @@ function RaidCore:CreateWorldMarker(key, sText, tPosition)
     markFrame:SetWorldLocation(tPosition)
     markFrame:FindChild("Name"):SetText(sText)
     self.worldmarker[key] = markFrame
-    self:WorldMarkerVisibilityHandler(key)
+    self:MarkerVisibilityHandler(markFrame)
 end
 
 function RaidCore:UpdateWorldMarker(key, sText, tPosition)


### PR DESCRIPTION
Previously we had already fixed the issue where world markers were
displayed on the wrong location on the screen when the position
coordinates were not on our screen. This commit extends that
functionality to marking of units as well.
