### PR TITLE
Watch avatus when it is created

### DIFF
--- a/Encounters/DS/Avatus.lua
+++ b/Encounters/DS/Avatus.lua
@@ -243,7 +243,13 @@ end
 
 function mod:OnUnitCreated(unit, sName)
     local eventTime = GameLib.GetGameTime()
-    if sName == self.L["Holo Hand"] then
+    if sName == self.L["Avatus"] then
+        core:AddUnit(unit)
+        core:WatchUnit(unit)
+        if mod:GetSetting("LineCleaveBoss") then
+            core:AddPixie(unit:GetId(), 2, unit, nil, "Green", 10, 22, 0)
+        end
+    elseif sName == self.L["Holo Hand"] then
         local unitId = unit:GetId()
         core:AddUnit(unit)
         core:WatchUnit(unit)


### PR DESCRIPTION
When we enter the midphase the avatus unit is destroyed. So when we
leave the portal phase, we need to watch / add the unit again and add a
line if needed. Otherwise it only works before the portal phase.
