### PR TITLE
Encounters/GA: Bugfix, the %s pattern is not replaced properly in some messages

### DIFF
--- a/Encounters/GA/ExperimentX89.lua
+++ b/Encounters/GA/ExperimentX89.lua
@@ -138,7 +138,7 @@ end
 function mod:OnDebuffAdd(nId, nSpellId, nStack, fTimeRemaining)
     if nSpellId == DEBUFF_LITTLE_BOMB then
         local sSound = nId == GetPlayerUnit():GetId() and "RunAway"
-        core:AddMsg("LITTLEB", self.L["LITTLE BOMB on %s !!!"], 5, sSound, "Blue")
+        core:AddMsg("LITTLEB", self.L["LITTLE BOMB on %s !!!"]:format(GameLib.GetUnitById(nId):GetName()), 5, sSound, "Blue")
         core:AddTimerBar("LITTLEB", "LITTLE BOMB", fTimeRemaining)
     end
 end


### PR DESCRIPTION
Just in case, I made the test for the other files and this one seems to be the only one:

``` bash
$ grep -r 'self.L' Encounters/ | grep '%s' | grep -v :format
Encounters/GA/ExperimentX89.lua:        core:AddMsg("LITTLEB", self.L["LITTLE BOMB on %s !!!"], 5, sSound, "Blue")
```
