### PR TITLE
Update GeminiDB library

### DIFF
--- a/Libs/GeminiDB/GeminiDB-1.0.lua
+++ b/Libs/GeminiDB/GeminiDB-1.0.lua
@@ -32,7 +32,7 @@
 -- end
 -- @class file
 -- @name GeminiDB-1.0.lua
-local MAJOR, MINOR = "Gemini:DB-1.0", 6
+local MAJOR, MINOR = "Gemini:DB-1.0", 7
 local APkg = Apollo.GetPackage(MAJOR)
 if APkg and (APkg.nVersion or 0) >= MINOR then
 	return -- no upgrade is needed
@@ -282,7 +282,7 @@ local preserve_keys = {
 }
 
 local realmKey = GameLib.GetRealmName()
-local charKey = GameLib.GetAccountRealmCharacter().strCharacter .. " - " .. realmKey
+local charKey = GameLib.GetPlayerCharacterName() .. " - " .. realmKey
 local localeKey = GetLocale():lower()
 
 local function populateKeys(self)


### PR DESCRIPTION
With the latest patch `GetAccountRealmCharacter` has been deprecated and got replaced with different functions. It will be removed in one of the next patches and when that happens it will break GeminiDB and thus break RaidCore. 

This PR includes the newest version of GeminiDB to prevent this from happening so just need a version bump to push it to curse.
